### PR TITLE
fix: path to packaged binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "decentraland",
-      "version": "0.0.4",
+      "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^5.18.1",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -4,7 +4,7 @@ import { getExtensionPath } from '../utils/path'
 import { getNonce } from '../utils/webviews'
 import { loader } from '../utils/loader'
 import { getPort, getServerUrl, ServerName, waitForServer } from '../utils/port'
-import { exec } from '../utils/run'
+import { bin } from '../utils/bin'
 import { SpanwedChild } from '../utils/spawn'
 
 let child: SpanwedChild | null = null
@@ -50,7 +50,12 @@ export async function deploy(...args: string[]) {
 
   // start server
   const port = await getPort(ServerName.DCLDeploy)
-  child = exec('dcl', ['deploy', `--port ${port}`, `--no-browser`, ...args])
+  child = bin('decentraland', 'dcl', [
+    'deploy',
+    `--port ${port}`,
+    `--no-browser`,
+    ...args,
+  ])
 
   // Catch main promise, show error only if server is not up yet (if it fails later there are already try/catchs for that)
   let isLoaded = false

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import { loader } from '../utils/loader'
 import { npmInstall } from '../utils/npm'
 import { getTypeOptions, ProjectType } from '../utils/project'
-import { exec } from '../utils/run'
+import { bin } from '../utils/bin'
 
 export async function init(type?: ProjectType) {
   const options = getTypeOptions()
@@ -30,7 +30,7 @@ export async function init(type?: ProjectType) {
     option = options.find((option) => option.name === selected)!
   }
 
-  const child = exec('dcl', [
+  const child = bin('decentraland', 'dcl', [
     'init',
     `--project ${option.type}`,
     `--skip-install`,

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode'
-import { loader } from '../utils/loader'
 import { npmUninstall } from '../utils/npm'
-import { exec } from '../utils/run'
 
 export async function uninstall() {
   const dependency = await vscode.window.showInputBox({

--- a/src/utils/bin.ts
+++ b/src/utils/bin.ts
@@ -1,18 +1,21 @@
+import { log } from './log'
 import { getLocalBinPath } from './path'
 import { spawn, SpawnOptions } from './spawn'
 
 /**
- * Runs an npm command binary from the local binaries
+ * Runs an command binary from the local modules
+ * @param moduleName The name of the module that has the command
  * @param command The command, like 'dcl' or 'npm'
  * @param args The arguments for the command, like 'install' or 'start'
  * @param options Options for the child process spawned
  * @returns Promise<void>
  */
-export function exec(
+export function bin(
+  moduleName: string,
   command: string,
   args: string[] = [],
   options: SpawnOptions = {}
 ) {
-  const path = getLocalBinPath(command)
+  const path = getLocalBinPath(moduleName, command)
   return spawn(path, args, options)
 }

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import { loader } from './loader'
-import { exec } from './run'
+import { bin } from './bin'
 import { sleep } from './sleep'
 
 /**
@@ -14,7 +14,7 @@ export async function npmInstall(...dependencies: string[]) {
       dependencies.length > 0
         ? `Installing ${dependencies.join(', ')}...`
         : `Installing dependencies...`,
-      () => exec('npm', ['install', ...dependencies]).wait(),
+      () => bin('npm', 'npm', ['install', ...dependencies]).wait(),
       dependencies.length > 0
         ? vscode.ProgressLocation.Window
         : vscode.ProgressLocation.Notification
@@ -36,7 +36,7 @@ export async function npmInstall(...dependencies: string[]) {
 export async function npmUninstall(...dependencies: string[]) {
   if (dependencies.length > 0) {
     return loader(`Uninstalling ${dependencies.join(', ')}...`, () =>
-      exec('npm', ['uninstall', ...dependencies]).wait()
+      bin('npm', 'npm', ['uninstall', ...dependencies]).wait()
     )
   }
 }


### PR DESCRIPTION
Fixes #14 

The problem was that the prior approached looked for the inaries in the extension's `node_modules/.bin`, but it looks like that `.bin` directory does not exist in the packaged extension as it does on the development env. So I changed the approach to instead look for the `bin` property in the `package.json` of the given module, and use that path to the binary instead of the symlink in the `.bin` directory.