### PR TITLE
feat: add --save-bundle flag when installing dependencies

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -14,7 +14,11 @@ export async function npmInstall(...dependencies: string[]) {
       dependencies.length > 0
         ? `Installing ${dependencies.join(', ')}...`
         : `Installing dependencies...`,
-      () => bin('npm', 'npm', ['install', ...dependencies]).wait(),
+      () =>
+        bin('npm', 'npm', [
+          dependencies.length === 0 ? 'install' : 'install --save-bundle',
+          ...dependencies,
+        ]).wait(),
       dependencies.length > 0
         ? vscode.ProgressLocation.Window
         : vscode.ProgressLocation.Notification


### PR DESCRIPTION
Closes #19 

We pass the `--save-bundle` only when the user is "adding" a dependency (ie. `npm install --save-bundle decentraland-ecs-utils`), not when "syncing" (a regular `npm install`).