### PR TITLE
feat: install node binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dcl/schemas": "^5.18.1",
         "@dcl/wearable-preview": "^1.14.0",
+        "@types/semver": "^7.3.13",
         "cross-spawn": "^7.0.3",
         "decentraland": "^3.14.0-20221025200823.commit-2e3f738",
         "decentraland-ecs": "^6.11.9",
@@ -21,6 +22,7 @@
         "npm": "^8.19.2",
         "open": "^8.4.0",
         "rimraf": "^3.0.2",
+        "semver": "^7.3.8",
         "tar-fs": "^2.1.1"
       },
       "devDependencies": {
@@ -29,6 +31,7 @@
         "@types/gunzip-maybe": "^1.4.0",
         "@types/node": "^16.11.7",
         "@types/npm": "^7.19.0",
+        "@types/rimraf": "^3.0.2",
         "@types/tar-fs": "^2.0.1",
         "@types/vscode": "^1.65.0",
         "eslint": "^8.13.0",
@@ -37,6 +40,7 @@
         "vsce": "^2.13.0"
       },
       "engines": {
+        "node": "^16.0.0",
         "vscode": "^1.65.0"
       }
     },
@@ -553,6 +557,16 @@
         "form-data": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
@@ -603,6 +617,12 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "16.11.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
@@ -648,6 +668,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
@@ -8582,6 +8617,16 @@
         "form-data": "*"
       }
     },
+    "@types/glob": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
@@ -8632,6 +8677,12 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
@@ -8677,6 +8728,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "@types/serve-static": {
       "version": "1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,15 +16,20 @@
         "decentraland-ecs": "^6.11.9",
         "express": "^4.18.2",
         "fp-future": "^1.0.1",
+        "gunzip-maybe": "^1.4.2",
         "node-fetch": "^2.6.7",
         "npm": "^8.19.2",
-        "open": "^8.4.0"
+        "open": "^8.4.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.1.1"
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.2",
         "@types/express": "^4.17.14",
+        "@types/gunzip-maybe": "^1.4.0",
         "@types/node": "^16.11.7",
         "@types/npm": "^7.19.0",
+        "@types/tar-fs": "^2.0.1",
         "@types/vscode": "^1.65.0",
         "eslint": "^8.13.0",
         "prettier": "^2.7.1",
@@ -553,6 +558,15 @@
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
       "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
+    "node_modules/@types/gunzip-maybe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz",
+      "integrity": "sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -641,6 +655,25 @@
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "dependencies": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-qlsQyIY9sN7p221xHuXKNoMfUenOcvEBN4zI8dGsYbYCqHtTarXOEXSIgUnK+GcR0fZDse6pAIc5pIrCh9NefQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
+      "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1161,6 +1194,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1369,8 +1410,7 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/cids": {
       "version": "1.1.9",
@@ -2084,6 +2124,44 @@
         "detect-libc": "^1.0.3"
       }
     },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2788,6 +2866,30 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/gunzip-maybe": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
+      "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
+      "dependencies": {
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
+      },
+      "bin": {
+        "gunzip-maybe": "bin.js"
+      }
+    },
+    "node_modules/gunzip-maybe/node_modules/is-gzip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+      "integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -3136,6 +3238,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "node_modules/is-deflate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+      "integrity": "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ=="
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
@@ -3669,8 +3776,7 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -6464,6 +6570,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6547,6 +6658,16 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -6731,6 +6852,25 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "node_modules/pumpify/node_modules/pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6985,7 +7125,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7234,6 +7373,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7293,7 +7437,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -7384,6 +7527,42 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -7913,6 +8092,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -8400,6 +8587,15 @@
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
       "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
+    "@types/gunzip-maybe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/gunzip-maybe/-/gunzip-maybe-1.4.0.tgz",
+      "integrity": "sha512-dFP9GrYAR9KhsjTkWJ8q8Gsfql75YIKcg9DuQOj/IrlPzR7W+1zX+cclw1McV82UXAQ+Lpufvgk3e9bC8+HzgA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -8488,6 +8684,25 @@
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "requires": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-qlsQyIY9sN7p221xHuXKNoMfUenOcvEBN4zI8dGsYbYCqHtTarXOEXSIgUnK+GcR0fZDse6pAIc5pIrCh9NefQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "@types/tar-stream": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
+      "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -8923,6 +9138,14 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "requires": {
+        "pako": "~0.2.0"
+      }
+    },
     "buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -9065,8 +9288,7 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "cids": {
       "version": "1.1.9",
@@ -9599,6 +9821,46 @@
       "integrity": "sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==",
       "requires": {
         "detect-libc": "^1.0.3"
+      }
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "ee-first": {
@@ -10149,6 +10411,26 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "gunzip-maybe": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
+      "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
+      "requires": {
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "is-gzip": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+          "integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ=="
+        }
+      }
+    },
     "hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
@@ -10401,6 +10683,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-deflate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+      "integrity": "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ=="
     },
     "is-docker": {
       "version": "2.2.1",
@@ -10823,8 +11110,7 @@
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "ms": {
       "version": "2.1.2",
@@ -12724,6 +13010,11 @@
         "semver": "^7.3.5"
       }
     },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12788,6 +13079,16 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -12937,6 +13238,27 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "punycode": {
@@ -13126,7 +13448,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -13300,6 +13621,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -13344,7 +13670,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -13414,6 +13739,44 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "tmp": {
       "version": "0.0.33",
@@ -13821,6 +14184,11 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/decentraland/editor"
   },
   "engines": {
+    "node": "^16.0.0",
     "vscode": "^1.65.0"
   },
   "categories": [
@@ -308,6 +309,7 @@
     "@types/gunzip-maybe": "^1.4.0",
     "@types/node": "^16.11.7",
     "@types/npm": "^7.19.0",
+    "@types/rimraf": "^3.0.2",
     "@types/tar-fs": "^2.0.1",
     "@types/vscode": "^1.65.0",
     "eslint": "^8.13.0",
@@ -323,6 +325,7 @@
   "dependencies": {
     "@dcl/schemas": "^5.18.1",
     "@dcl/wearable-preview": "^1.14.0",
+    "@types/semver": "^7.3.13",
     "cross-spawn": "^7.0.3",
     "decentraland": "^3.14.0-20221025200823.commit-2e3f738",
     "decentraland-ecs": "^6.11.9",
@@ -333,6 +336,7 @@
     "npm": "^8.19.2",
     "open": "^8.4.0",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.8",
     "tar-fs": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -305,8 +305,10 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
     "@types/express": "^4.17.14",
+    "@types/gunzip-maybe": "^1.4.0",
     "@types/node": "^16.11.7",
     "@types/npm": "^7.19.0",
+    "@types/tar-fs": "^2.0.1",
     "@types/vscode": "^1.65.0",
     "eslint": "^8.13.0",
     "prettier": "^2.7.1",
@@ -326,8 +328,11 @@
     "decentraland-ecs": "^6.11.9",
     "express": "^4.18.2",
     "fp-future": "^1.0.1",
+    "gunzip-maybe": "^1.4.2",
     "node-fetch": "^2.6.7",
     "npm": "^8.19.2",
-    "open": "^8.4.0"
+    "open": "^8.4.0",
+    "rimraf": "^3.0.2",
+    "tar-fs": "^2.1.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import {
   startServer as startDCLPreview,
   stopServer as stopDCLPreview,
 } from './dcl-preview/server'
-import { getCwd, isDCL, isEmpty, setExtensionPath } from './utils/path'
+import { getCwd, getNodeBinPath, isDCL, isEmpty, setExtensionPath, setGlobalStoragePath } from './utils/path'
 import { install } from './commands/install'
 import { start } from './commands/start'
 import { browser } from './commands/browser'
@@ -20,10 +20,12 @@ import { Dependency } from './dependencies/types'
 import { npmInstall, npmUninstall } from './utils/npm'
 import { ServerName } from './utils/port'
 import { ProjectType } from './utils/project'
+import { download } from './utils/node'
 
 export async function activate(context: vscode.ExtensionContext) {
-  // Set extension path
+  // Set paths
   setExtensionPath(context.extensionUri.fsPath)
+  setGlobalStoragePath(context.globalStorageUri.fsPath)
 
   // Dependency tree (UI)
   let dependencies: DependenciesProvider | null = null
@@ -103,6 +105,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Validate the project folder
   await validate()
+
+  // Download node
+  await download()
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import {
   startServer as startDCLPreview,
   stopServer as stopDCLPreview,
 } from './dcl-preview/server'
-import { getCwd, getNodeBinPath, isDCL, isEmpty, setExtensionPath, setGlobalStoragePath } from './utils/path'
+import { getCwd, isDCL, isEmpty, setExtensionPath, setGlobalStoragePath } from './utils/path'
 import { install } from './commands/install'
 import { start } from './commands/start'
 import { browser } from './commands/browser'
@@ -20,12 +20,15 @@ import { Dependency } from './dependencies/types'
 import { npmInstall, npmUninstall } from './utils/npm'
 import { ServerName } from './utils/port'
 import { ProjectType } from './utils/project'
-import { download } from './utils/node'
+import { download, resolveVersion, setVersion } from './utils/node'
 
 export async function activate(context: vscode.ExtensionContext) {
   // Set paths
   setExtensionPath(context.extensionUri.fsPath)
   setGlobalStoragePath(context.globalStorageUri.fsPath)
+
+  // Set node binary version
+  setVersion(await resolveVersion())
 
   // Dependency tree (UI)
   let dependencies: DependenciesProvider | null = null

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { Dependency } from './dependencies/types'
 import { npmInstall, npmUninstall } from './utils/npm'
 import { ServerName } from './utils/port'
 import { ProjectType } from './utils/project'
-import { download, resolveVersion, setVersion } from './utils/node'
+import { checkBinaries, resolveVersion, setVersion } from './utils/node'
 
 export async function activate(context: vscode.ExtensionContext) {
   // Set paths
@@ -109,8 +109,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // Validate the project folder
   await validate()
 
-  // Download node
-  await download()
+  // Check node binaries, download them if necessary
+  await checkBinaries()
 }
 
 export async function deactivate() {

--- a/src/utils/bin.ts
+++ b/src/utils/bin.ts
@@ -1,5 +1,4 @@
-import { log } from './log'
-import { getLocalBinPath } from './path'
+import { getModuleBinPath, getNodeBinPath } from './path'
 import { spawn, SpawnOptions } from './spawn'
 
 /**
@@ -16,6 +15,7 @@ export function bin(
   args: string[] = [],
   options: SpawnOptions = {}
 ) {
-  const path = getLocalBinPath(moduleName, command)
-  return spawn(path, args, options)
+  const node = getNodeBinPath().replace(/\s/g, "\\ ") // fix whitespaces 
+  const bin = getModuleBinPath(moduleName, command)
+  return spawn(node, [bin, ...args], options)
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -5,6 +5,6 @@ const output = vscode.window.createOutputChannel(`Decentraland`)
  * Util to print messages to the Output channel
  * @param message a string to print
  */
-export function log(message: string) {
-  output.appendLine(message)
+export function log(...messages: string[]) {
+  output.appendLine(messages.join(' '))
 }

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -218,7 +218,7 @@ async function uninstall(distribution: string) {
 }
 
 /**
- * This checks if the necessary binaries are installed. If not, then it proceeds to uninstall older distributions and installed the expected one.
+ * This checks if the necessary binaries are installed. If not, it proceeds to uninstall older distributions and install the expected one.
  * @returns 
  */
 export async function checkBinaries() {

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,17 +1,121 @@
 import fs from 'fs'
+import path from 'path';
+import semver from 'semver'
+import rimraf from 'rimraf'
 import fetch from 'node-fetch';
 import tar from 'tar-fs'
 import gunzip from 'gunzip-maybe';
 import future from 'fp-future';
-import { getGlobalStoragePath, getNodeBinPath } from "./path"
+import { getGlobalStoragePath, getNodeBinPath } from './path'
 import { log } from './log';
+import { getPackageJson } from './pkg';
 
 /**
  * Returns the node version that will be used to run binaries
  * @returns node version
  */
+let version: string | null
 export function getVersion() {
-  return process.version
+  if (version === null) {
+    throw new Error(`Node version not set`)
+  }
+  return version
+}
+
+export function setVersion(_version: string) {
+  version = _version
+}
+
+/**
+ * Fetches the latest supported node version
+ */
+export async function resolveVersion() {
+  const pkg = getPackageJson()
+  const min = semver.minVersion(pkg.engines.node)
+  if (!min) {
+    throw new Error(`Could not resolve minimum node version. The value found in the package.json for engines.node is "${pkg.engines.node}".`)
+  }
+  log(`Node engine required: ${pkg.engines.node}`)
+
+  const installed = await getLatestFromInstalled(min.major)
+  if (installed) {
+    log(`Latest node version installed: ${installed}`)
+  }
+
+  const latest = await getLatestFromGithub(min.major)
+  if (latest) {
+    log(`Latest node version available: ${latest}`)
+  }
+
+  const version = latest || installed || min.version
+  log(`Using node version: v${version}`)
+  return version
+}
+
+
+/**
+ * Extracts the version from the distribution
+ * @param distribution 
+ * @returns 
+ */
+function extractVersion(distribution: string) {
+  return distribution.split('node-v').pop()?.split('-')[0]!
+}
+
+/**
+ * Get the latest version of node installed
+ * @returns 
+ */
+async function getLatestFromInstalled(major: number) {
+  const distributions = await getInstalledDistributions()
+  return distributions
+    .map(extractVersion)
+    .reduce<string | null>((latest, version) => !latest || (semver.gt(version, latest) && semver.satisfies(version, `^${major}.0.0`)) ? version : latest, null)
+}
+
+/**
+ * Get the list of installed distributions
+ * @returns 
+ */
+async function getInstalledDistributions() {
+  const versions = future<string[]>()
+  fs.readdir(getGlobalStoragePath(), (error, result) => error ? versions.reject(error) : versions.resolve(result))
+  return versions
+}
+
+async function getLatestFromGithub(major: number, page = 1): Promise<string | null> {
+  try {
+    const versions = await getAvailableVersions(page)
+
+    let latest: string | null = null
+    for (const version of versions) {
+      const inRange = semver.satisfies(version, `^${major}.0.0`)
+      const isNewer = !latest || semver.gt(version, latest)
+      if (inRange && isNewer) {
+        latest = version
+      }
+    }
+
+    // if no version found in this page, look in the next one
+    if (latest === null) {
+      return getLatestFromGithub(major, page + 1)
+    }
+
+    // if the latest version was found in this page, we use that one
+    return latest
+  } catch (error: any) {
+    log(`Could not look for newer versions...`)
+    return null
+  }
+}
+
+async function getAvailableVersions(page: number) {
+  const resp = await fetch(`https://api.github.com/repos/nodejs/node/tags?per_page=10&page=${page}`)
+  if (!resp.ok) {
+    throw new Error(`Error fetching available node versions: ${await resp.text()}`)
+  }
+  const tags: { name: string }[] = await resp.json()
+  return tags.map(({ name }) => semver.clean(name)!)
 }
 
 /**
@@ -60,7 +164,7 @@ export function getPlatform() {
 }
 
 export function getDistribution() {
-  return `node-${getVersion()}-${getPlatform()}`
+  return `node-v${getVersion()}-${getPlatform()}`
 }
 
 
@@ -69,13 +173,24 @@ export async function download() {
   const binPath = getNodeBinPath()
   const isNodeInstalled = fs.existsSync(binPath)
   if (isNodeInstalled) {
-    log(`node is already installed: ${getVersion()}`)
     return
   }
-  log('installing node')
   const dist = getDistribution()
-  const url = `https://nodejs.org/dist/${version}/${dist}.tar.gz`
-  log('dist', dist)
+  log(`Node binaries not installed`)
+  const globalStoragePath = getGlobalStoragePath()
+  const distributions = await getInstalledDistributions()
+  if (distributions.length > 0) {
+    log(`Clearing up binaries directory...`)
+    for (const distribution of distributions) {
+      const directory = path.join(globalStoragePath, distribution)
+      const clear = future<void>()
+      rimraf(directory, error => error ? clear.reject(error) : clear.resolve())
+      await clear
+    }
+    log(`Done!`)
+  }
+  log(`Installing ${dist}...`)
+  const url = `https://nodejs.org/dist/v${version}/${dist}.tar.gz`
   const resp = await fetch(url)
   if (!resp.ok) {
     let error = `Could not download "${dist}"`
@@ -86,14 +201,11 @@ export async function download() {
     }
     throw new Error(error)
   }
-  log('response ok', resp.ok.toString())
   const save = future()
-  // TODO: check if directory already exist, rimraf it if it does
-  log('saving to file system:', getGlobalStoragePath())
   const stream = tar.extract(getGlobalStoragePath(), {})
   resp.body.pipe(gunzip()).pipe(stream)
   resp.body.on('end', save.resolve)
   stream.on('error', save.reject)
   await save
-  log('saved!')
+  log('Done!')
 }

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,0 +1,99 @@
+import fs from 'fs'
+import fetch from 'node-fetch';
+import tar from 'tar-fs'
+import gunzip from 'gunzip-maybe';
+import future from 'fp-future';
+import { getGlobalStoragePath, getNodeBinPath } from "./path"
+import { log } from './log';
+
+/**
+ * Returns the node version that will be used to run binaries
+ * @returns node version
+ */
+export function getVersion() {
+  return process.version
+}
+
+/**
+ * Returns the platform + arch needed for the binaries
+ * @returns 
+ */
+export function getPlatform() {
+  let platform = ''
+  switch (process.platform) {
+    case "darwin":
+      platform = "darwin"
+      break
+    case "win32":
+      platform = "win"
+      break
+    case "linux":
+      platform = "linux"
+      break
+    default:
+      throw new Error(`Unsupported platform: "${process.platform}"`)
+  }
+
+  platform += '-'
+
+  switch (process.arch) {
+    case "arm64":
+      platform += "arm64"
+      break
+    case "arm":
+      platform += "armv71"
+      break
+    case "x64":
+      platform += 'x64'
+      break
+    case "ppc64":
+      platform += 'ppc64le'
+      break
+    case "s390x":
+      platform += "s390x"
+      break
+    default:
+      throw new Error(`Unsupported architecture: "${process.arch}"`)
+  }
+
+  return platform
+}
+
+export function getDistribution() {
+  return `node-${getVersion()}-${getPlatform()}`
+}
+
+
+export async function download() {
+  const version = getVersion()
+  const binPath = getNodeBinPath()
+  const isNodeInstalled = fs.existsSync(binPath)
+  if (isNodeInstalled) {
+    log(`node is already installed: ${getVersion()}`)
+    return
+  }
+  log('installing node')
+  const dist = getDistribution()
+  const url = `https://nodejs.org/dist/${version}/${dist}.tar.gz`
+  log('dist', dist)
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    let error = `Could not download "${dist}"`
+    try {
+      error += `: ${await resp.text()}`
+    } catch (error) {
+      console.warn(`Could not parse response body as text`)
+    }
+    throw new Error(error)
+  }
+  log('response ok', resp.ok.toString())
+  const save = future()
+  // TODO: check if directory already exist, rimraf it if it does
+  log('saving to file system:', getGlobalStoragePath())
+  const stream = tar.extract(getGlobalStoragePath(), {})
+  resp.body.pipe(gunzip()).pipe(stream)
+  resp.body.on('end', save.resolve)
+  stream.on('error', save.reject)
+  await save
+  log('saved!')
+}

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -37,7 +37,7 @@ export async function npmInstall(...dependencies: string[]) {
  */
 export async function npmUninstall(...dependencies: string[]) {
   if (dependencies.length > 0) {
-    return loader(`Uninstalling ${dependencies.join(', ')}...`, async () =>
+    return loader(`Uninstalling ${dependencies.join(', ')}...`, () =>
       bin('npm', 'npm', ['uninstall', ...dependencies]).wait()
     )
   }

--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 import { loader } from './loader'
 import { bin } from './bin'
-import { sleep } from './sleep'
 
 /**
  * Installs a list of npm packages, or install all dependencies if no list is provided
@@ -25,8 +24,7 @@ export async function npmInstall(...dependencies: string[]) {
     )
   } catch (error) {
     vscode.window.showErrorMessage(
-      `Error installing ${
-        dependencies.length > 0 ? dependencies.join(', ') : 'dependencies'
+      `Error installing ${dependencies.length > 0 ? dependencies.join(', ') : 'dependencies'
       }`
     )
   }
@@ -39,7 +37,7 @@ export async function npmInstall(...dependencies: string[]) {
  */
 export async function npmUninstall(...dependencies: string[]) {
   if (dependencies.length > 0) {
-    return loader(`Uninstalling ${dependencies.join(', ')}...`, () =>
+    return loader(`Uninstalling ${dependencies.join(', ')}...`, async () =>
       bin('npm', 'npm', ['uninstall', ...dependencies]).wait()
     )
   }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -141,11 +141,19 @@ export function hasNodeModules() {
   }
 }
 
+/**
+ * Helper to get the absolute path to the directory where the extension stores binaries
+ * @returns The path to the node bin
+ */
+export function getGlobalBinPath() {
+  return `${getGlobalStoragePath()}/bin`
+}
+
 
 /**
- * Helper to get the absolute path to the node binary used by VSCode
+ * Helper to get the absolute path to the node binaries installed
  * @returns The path to the node bin
  */
 export function getNodeBinPath() {
-  return `${getGlobalStoragePath()}/${getDistribution()}/bin/node`
+  return `${getGlobalBinPath()}/${getDistribution()}/bin/node`
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import path from 'path'
 import fs from 'fs'
 import { getDistribution, } from './node'
+import { getPackageJson } from './pkg'
 
 // Stores path to the extension's directory in the filesystem
 let extensionPath: string | null = null
@@ -139,28 +140,7 @@ export function hasNodeModules() {
     return false
   }
 }
-/**
- * Return the package json of a given module
- * @param moduleName The name of the module
- * @returns The package json object
- */
-export function getPackageJson(moduleName: string): {
-  bin?: { [command: string]: string }
-} {
-  const packageJsonPath = path.join(
-    getExtensionPath(),
-    './node_modules',
-    moduleName,
-    'package.json'
-  )
-  try {
-    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-  } catch (error: any) {
-    throw new Error(
-      `Could not get package.json for module "${moduleName}": ${error.message}`
-    )
-  }
-}
+
 
 /**
  * Helper to get the absolute path to the node binary used by VSCode

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode'
 import path from 'path'
 import fs from 'fs'
+import { getDistribution, } from './node'
 
 // Stores path to the extension's directory in the filesystem
 let extensionPath: string | null = null
+
+// Stores path to the extension's global storage in the filesystem
+let globalStoragePath: string | null = null
 
 /**
  * Set the path to the extension's directory in the filesystem
@@ -32,11 +36,37 @@ export function getExtensionPath() {
 }
 
 /**
+ * Set the path to the extension's directory in the filesystem
+ * @param path Path to the extension
+ */
+export function setGlobalStoragePath(path: string | null) {
+  console.log(
+    path == null
+      ? 'Global storage path has been unset'
+      : `Global storage has been set to "${path}".`
+  )
+  globalStoragePath = path
+}
+
+/**
+ * Returns the path to the global storage in the filesystem
+ * @returns Path to the global storage
+ */
+export function getGlobalStoragePath() {
+  if (globalStoragePath == null) {
+    throw new Error(
+      'Global storage path has not been set, probably because the extension has not been activated yet.'
+    )
+  }
+  return globalStoragePath
+}
+
+/**
  * Return the path to an extension's dependency binary in the filesystem
  * @param moduleName The name of the module
  * @returns The path to the binary
  */
-export function getLocalBinPath(moduleName: string, command: string) {
+export function getModuleBinPath(moduleName: string, command: string) {
   const packageJson = getPackageJson(moduleName)
   if (!packageJson.bin) {
     throw new Error(`the module "${moduleName}" does not have a binary`)
@@ -130,4 +160,12 @@ export function getPackageJson(moduleName: string): {
       `Could not get package.json for module "${moduleName}": ${error.message}`
     )
   }
+}
+
+/**
+ * Helper to get the absolute path to the node binary used by VSCode
+ * @returns The path to the node bin
+ */
+export function getNodeBinPath() {
+  return `${getGlobalStoragePath()}/${getDistribution()}/bin/node`
 }

--- a/src/utils/pkg.ts
+++ b/src/utils/pkg.ts
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import path from 'path'
+import { getExtensionPath } from './path'
+
+/**
+ * Return the package json of a given module
+ * @param moduleName The name of the module
+ * @returns The package json object
+ */
+export function getPackageJson(moduleName?: string): {
+  engines: {
+    node: string
+  }
+  bin?: { [command: string]: string }
+} {
+  const packageJsonPath = typeof moduleName === 'string' ? path.join(
+    getExtensionPath(),
+    './node_modules',
+    moduleName,
+    'package.json'
+  ) : path.join(
+    getExtensionPath(),
+    'package.json'
+  )
+  try {
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  } catch (error: any) {
+    throw new Error(
+      `Could not get package.json for module "${moduleName}": ${error.message}`
+    )
+  }
+}


### PR DESCRIPTION
Fixes #24 

This PR adds logic to download the node binaries and use those instead of the ones installed in the `$PATH`.

The main reason for this is because the user may not have any binaries installed at all. Also it let us control the version of node that we want to use.

The logic to select the distribution is as follows: platform and arch are derived from the `process`, and the version used is the latest version for the major specified in the `engines.node` section of the package.json. To get the latest version I used the GitHub API to fetch the releases for the `nodejs/node` repo. This is optional tho, if the request fails for any reason (like rate limiting, since the API is being used unathenticated) then it will default to keep using the latest installed version, and if there's none installed (like the first time the extension is run) it will default to the version specified in the `engines.node` section (which is currently `16.0.0`).
