### PR TITLE
fix: validation before binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "gunzip-maybe": "^1.4.2",
         "is-running": "^2.1.0",
         "node-fetch": "^2.6.7",
+        "node-fetch-progress": "^1.0.2",
         "npm": "^8.19.2",
         "open": "^8.4.0",
         "rimraf": "^3.0.2",
@@ -1772,6 +1773,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+    },
+    "node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "node_modules/dcl-catalyst-client": {
       "version": "13.0.7",
@@ -4011,6 +4017,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-fetch-progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-progress/-/node-fetch-progress-1.0.2.tgz",
+      "integrity": "sha512-SHU7Ye0zcN/GHnjp2FMOLbJeJQ4ji68nicY6yF13VAmEZZKcbkjl3btkYmmtbVaL3gKoQxxba7WfTM6zOMUMyg==",
+      "dependencies": {
+        "bytes": "^3.0.0",
+        "date-fns": "^1.30.1",
+        "throttle-debounce": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/node-gyp-build": {
@@ -7572,6 +7591,14 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9620,6 +9647,11 @@
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
     "dcl-catalyst-client": {
       "version": "13.0.7",
       "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-13.0.7.tgz",
@@ -11353,6 +11385,16 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-fetch-progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-progress/-/node-fetch-progress-1.0.2.tgz",
+      "integrity": "sha512-SHU7Ye0zcN/GHnjp2FMOLbJeJQ4ji68nicY6yF13VAmEZZKcbkjl3btkYmmtbVaL3gKoQxxba7WfTM6zOMUMyg==",
+      "requires": {
+        "bytes": "^3.0.0",
+        "date-fns": "^1.30.1",
+        "throttle-debounce": "^2.1.0"
       }
     },
     "node-gyp-build": {
@@ -13825,6 +13867,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -362,6 +362,7 @@
     "gunzip-maybe": "^1.4.2",
     "is-running": "^2.1.0",
     "node-fetch": "^2.6.7",
+    "node-fetch-progress": "^1.0.2",
     "npm": "^8.19.2",
     "open": "^8.4.0",
     "rimraf": "^3.0.2",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,8 +11,8 @@ export async function init(type?: ProjectType) {
     type: ProjectType
     name: string
   } | null = type
-    ? options.find((option) => option.type === type) || null
-    : null
+      ? options.find((option) => option.type === type) || null
+      : null
 
   if (!option) {
     const selected = await vscode.window.showQuickPick(

--- a/src/dcl-preview/server.ts
+++ b/src/dcl-preview/server.ts
@@ -27,7 +27,7 @@ export async function startServer() {
 
     const port = await getPort(ServerName.DCLPreview)
 
-    log(`DCLPreview: preview server started on port ${port}`)
+    log(`DCLPreview: http server listening on port ${port}`)
 
     child = bin('decentraland', 'dcl', [
       'start',
@@ -46,7 +46,7 @@ export async function startServer() {
 
     child.process.on('close', (code) => {
       if (code !== null) {
-        log(`DCLPreview: closing server with status code ${code}`)
+        log(`DCLPreview: http server closed with status code ${code}`)
       }
       child = null
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,11 +85,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   }
 
-  // Validate the project folder
-  await validate()
-
   // Check node binaries, download them if necessary
   await checkBinaries()
+
+  // Validate the project folder
+  await validate()
 
   // watch for changes in node_modules
   watch()

--- a/src/untyped-modules.d.ts
+++ b/src/untyped-modules.d.ts
@@ -1,0 +1,24 @@
+
+declare module 'node-fetch-progress' {
+  import { Response } from 'node-fetch'
+  type ProgressData = {
+    total: number,
+    done: number,
+    totalh: number,
+    doneh: number,
+    startedAt: number,
+    elapsed: number,
+    rate: number,
+    rateh: number,
+    estimated: number,
+    progress: number,
+    eta: number,
+    etah: number,
+    etaDat: number,
+  }
+  class Progress {
+    constructor(response: Response)
+    on(eventName: 'progress', callback: (progress: ProgressData) => void): void
+  }
+  export default Progress
+}

--- a/src/utils/bin.ts
+++ b/src/utils/bin.ts
@@ -1,4 +1,4 @@
-import { getModuleBinPath, getNodeBinPath } from './path'
+import { escapeWhiteSpaces, getModuleBinPath, getNodeBinPath } from './path'
 import { spawn, SpawnOptions } from './spawn'
 
 /**
@@ -15,7 +15,7 @@ export function bin(
   args: (string | undefined)[] = [],
   options: SpawnOptions = {}
 ) {
-  const node = getNodeBinPath().replace(/\s/g, "\\ ") // fix whitespaces 
+  const node = escapeWhiteSpaces(getNodeBinPath())
   const bin = getModuleBinPath(moduleName, command)
-  return spawn(`${command}:${args[0]}`, node, [bin, ...args.filter((arg: string | undefined) => !!arg) as string[]], options)
+  return spawn(`${command} ${args[0]}`, node, [bin, ...args.filter((arg: string | undefined) => !!arg) as string[]], options)
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -3,12 +3,48 @@ import { SpanwedChild } from './spawn'
 
 const output = vscode.window.createOutputChannel(`Decentraland`)
 
+let outputData = ''
+
+/**
+ * Append a message to the output
+ */
+export function append(message: string) {
+  outputData += message
+  output.append(message)
+}
+
+/**
+ * Append a message to the output in a new line
+ */
+export function appendLine(message: string) {
+  const line = message + '\n'
+  outputData += line
+  output.append(line)
+}
+
+/**
+ * Replace the whole output channel
+ */
+export function replace(message: string) {
+  outputData = message
+  output.replace(message)
+}
+
+/**
+ * Clear output channel
+ */
+export function clear() {
+  outputData = ''
+  output.clear()
+}
+
 /**
  * Util to print messages to the Output channel
  * @param message a string to print
  */
 export function log(...messages: string[]) {
-  output.appendLine(messages.join(' '))
+  const line = messages.join(' ') + '\n'
+  append(line)
 }
 
 /**

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -19,7 +19,7 @@ export function setExtensionPath(path: string | null) {
   log(
     path == null
       ? 'Extension path has been unset'
-      : `Extension path has been set to ${path}.`
+      : `Extension path has been set to "${path}"`
   )
   extensionPath = path
 }
@@ -45,7 +45,7 @@ export function setGlobalStoragePath(path: string | null) {
   log(
     path == null
       ? 'Global storage path has been unset'
-      : `Global storage has been set to ${path}.`
+      : `Global storage has been set to "${path}"`
   )
   globalStoragePath = path
 }
@@ -157,4 +157,13 @@ export function getGlobalBinPath() {
  */
 export function getNodeBinPath() {
   return `${getGlobalBinPath()}/${getDistribution()}/bin/node`
+}
+
+/**
+ * Replace white spaces with "\ "
+ * @param p path to fix
+ * @returns fixed path
+ */
+export function escapeWhiteSpaces(p: string) {
+  return p.replace(/\s/g, "\\ ")
 }

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -103,7 +103,7 @@ export function spawn(
         }
       }),
     kill: async () => {
-      log(`${id}: killing process...`)
+      log(`Killing process "${id}"...`)
       // if child already killed, return
       if (killed) return
       killed = true
@@ -128,7 +128,7 @@ export function spawn(
       // interval to check if child still running and flag it as dead when is not running anymore
       const interval = setInterval(() => {
         if (!child.pid || !isRunning(child.pid)) {
-          log(`${id}: gracefully killed`)
+          log(`Process "${id}" gracefully killed`)
           die()
         }
       }, 100)
@@ -136,7 +136,7 @@ export function spawn(
       // timeout to stop checking if child still running, kil it with fire
       const timeout = setTimeout(() => {
         if (alive) {
-          log(`${id}: forcefully killed`)
+          log(`Process "${id}" forcefully killed`)
           die()
         }
       }, 5000)

--- a/src/utils/watch.ts
+++ b/src/utils/watch.ts
@@ -1,6 +1,5 @@
 import chokidar from 'chokidar'
 import path from 'path'
-import { startServer } from '../dcl-preview/server'
 import { refreshTree } from '../dependencies/tree'
 import { debounce } from './debounce'
 import { log } from './log'


### PR DESCRIPTION
This PR fixes an issue where the validation was being started before the node binaries were installed. This made the last step of the validation failed (starting the preview server) on a machine that did not have the binaries installed.

I also improved the logs a lot in this PR.