### PR TITLE
feat: enable web3 & test server

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,8 +157,14 @@
         "category": "Decentraland"
       },
       {
+        "command": "decentraland.commands.deployTest",
+        "title": "Publish Scene To Test Server",
+        "icon": "$(rocket)",
+        "category": "Decentraland"
+      },
+      {
         "command": "decentraland.commands.deployCustom",
-        "title": "Publish Scene To Custom Catalyst",
+        "title": "Publish Scene To Custom Server",
         "icon": "$(rocket)",
         "category": "Decentraland"
       },
@@ -225,14 +231,19 @@
       ],
       "view/title": [
         {
-          "command": "decentraland.commands.deployCustom",
+          "command": "decentraland.commands.deployTest",
           "when": "view == decentraland && decentraland.isDCL",
           "group": "1_actions@1"
         },
         {
-          "command": "decentraland.commands.browser.web3",
+          "command": "decentraland.commands.deployCustom",
           "when": "view == decentraland && decentraland.isDCL",
           "group": "1_actions@2"
+        },
+        {
+          "command": "decentraland.commands.browser.web3",
+          "when": "view == decentraland && decentraland.isDCL",
+          "group": "1_actions@3"
         },
         {
           "command": "decentraland.commands.restart",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
         "category": "Decentraland"
       },
       {
+        "command": "decentraland.commands.browser.web3",
+        "title": "Open In Browser With Web3",
+        "category": "Decentraland"
+      },
+      {
         "command": "decentraland.commands.browser.deploy",
         "title": "Open in browser",
         "category": "Decentraland"
@@ -222,7 +227,12 @@
         {
           "command": "decentraland.commands.deployCustom",
           "when": "view == decentraland && decentraland.isDCL",
-          "group": "1_actions"
+          "group": "1_actions@1"
+        },
+        {
+          "command": "decentraland.commands.browser.web3",
+          "when": "view == decentraland && decentraland.isDCL",
+          "group": "1_actions@2"
         },
         {
           "command": "decentraland.commands.restart",

--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -1,8 +1,8 @@
 import open = require('open')
 import { getServerParams, getServerUrl, ServerName } from '../modules/port'
 
-export async function browser(server: ServerName) {
+export async function browser(server: ServerName, extraParams = '') {
   const url = await getServerUrl(server)
   const params = getServerParams(server)
-  open(url.toString() + params)
+  open(url.toString() + params + extraParams)
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,6 +144,9 @@ export async function activate(context: vscode.ExtensionContext) {
     )
     registerCommand('decentraland.commands.restart', () => restart())
     registerCommand('decentraland.commands.deploy', () => deploy())
+    registerCommand('decentraland.commands.deployTest', async () =>
+      deploy(`--target peer-testing.decentraland.org`)
+    )
     registerCommand('decentraland.commands.deployCustom', async () =>
       deploy(
         `--target ${await vscode.window.showInputBox({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,6 +159,9 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommand('decentraland.commands.browser.deploy', () =>
       browser(ServerName.DCLDeploy)
     )
+    registerCommand('decentraland.commands.browser.web3', () =>
+      browser(ServerName.DCLPreview, '&ENABLE_WEB3')
+    )
 
     // Dependencies
     registerTree(disposables)


### PR DESCRIPTION
This PR adds support for enabling web3 and deploying to test server

The command `Open In Browser With Web3` has been added to the command pallete:
<img width="965" alt="Screenshot 2022-12-23 at 10 51 12" src="https://user-images.githubusercontent.com/2781777/209364225-ad6d971b-d072-4004-999a-1aafab2b115d.png">

Same for the `Publish Scene To Test Server`, and they are all available in the three dot menu:
<img width="315" alt="Screenshot 2022-12-23 at 12 49 04" src="https://user-images.githubusercontent.com/2781777/209364277-b69fe4e6-45ff-44f9-a658-22a52a917b69.png">

