### PR TITLE
feat: upgrade cli to v3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "chokidar": "^3.5.3",
         "cmd-shim": "^6.0.0",
         "cross-spawn": "^7.0.3",
-        "decentraland": "^3.14.2",
+        "decentraland": "^3.15.0",
         "decentraland-ecs": "^6.11.11",
         "dotenv": "^16.0.3",
         "estrella": "^1.4.1",
@@ -755,9 +755,9 @@
       "integrity": "sha512-7N6Rpyt/dWh/6azbccAtrExGRqmWqNp3fEMNuJFXHJn6ujEwwSweKtkwLllyYLHnzPPe3VSq/tmCsxvKv+0Rog=="
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
-      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.6.0.tgz",
+      "integrity": "sha512-HAxvQLOPM5g4+rnivD2LlgCVVJdSml4fOWoxNwp5XOayB6HTd/lRUedWOXgxbzo5L5iLrR7obMirnzvnHeFjlA=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.0",
@@ -3686,13 +3686,13 @@
       }
     },
     "node_modules/decentraland": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/decentraland/-/decentraland-3.14.2.tgz",
-      "integrity": "sha512-fPxPuLgwZVUv9/f9Q1w//2VrX6j54vcErqfeZA4PsfPaQDHxFFCFeURl5WnAr3IaJ4BimCmS0kjCB1lDq83CkA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/decentraland/-/decentraland-3.15.0.tgz",
+      "integrity": "sha512-Z9DV3Pj78ai81oAWcvKvhH8BUBu0Ds47imRkuhRXtfENKRD7surZ8BbWkwy9RqJL1694JjRFVWYZThvEPvVCTg==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/ecs-scene-utils": "^1.7.5",
-        "@dcl/linker-dapp": "^0.4.0",
+        "@dcl/linker-dapp": "^0.6.0",
         "@dcl/mini-comms": "1.0.0",
         "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
         "@dcl/schemas": "^5.14.0",
@@ -6265,9 +6265,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -12371,9 +12371,9 @@
       "integrity": "sha512-7N6Rpyt/dWh/6azbccAtrExGRqmWqNp3fEMNuJFXHJn6ujEwwSweKtkwLllyYLHnzPPe3VSq/tmCsxvKv+0Rog=="
     },
     "@dcl/linker-dapp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.4.0.tgz",
-      "integrity": "sha512-yLipflkauKxEdf9FNqM3yYWQaGG8t3A4eb7DXhae1ZM29qQXv0dQvio5tKFK1fxgGsj9v+CqLrvnDF2fwvmeoA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.6.0.tgz",
+      "integrity": "sha512-HAxvQLOPM5g4+rnivD2LlgCVVJdSml4fOWoxNwp5XOayB6HTd/lRUedWOXgxbzo5L5iLrR7obMirnzvnHeFjlA=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.0",
@@ -14743,13 +14743,13 @@
       }
     },
     "decentraland": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/decentraland/-/decentraland-3.14.2.tgz",
-      "integrity": "sha512-fPxPuLgwZVUv9/f9Q1w//2VrX6j54vcErqfeZA4PsfPaQDHxFFCFeURl5WnAr3IaJ4BimCmS0kjCB1lDq83CkA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/decentraland/-/decentraland-3.15.0.tgz",
+      "integrity": "sha512-Z9DV3Pj78ai81oAWcvKvhH8BUBu0Ds47imRkuhRXtfENKRD7surZ8BbWkwy9RqJL1694JjRFVWYZThvEPvVCTg==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/ecs-scene-utils": "^1.7.5",
-        "@dcl/linker-dapp": "^0.4.0",
+        "@dcl/linker-dapp": "^0.6.0",
         "@dcl/mini-comms": "1.0.0",
         "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-3130782694.commit-94713ab.tgz",
         "@dcl/schemas": "^5.14.0",
@@ -16691,9 +16691,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
     "chokidar": "^3.5.3",
     "cmd-shim": "^6.0.0",
     "cross-spawn": "^7.0.3",
-    "decentraland": "^3.14.2",
+    "decentraland": "^3.15.0",
     "decentraland-ecs": "^6.11.11",
     "dotenv": "^16.0.3",
     "estrella": "^1.4.1",

--- a/src/modules/sdk.spec.ts
+++ b/src/modules/sdk.spec.ts
@@ -18,8 +18,8 @@ const getPackageVersionMock = getPackageVersion as jest.MockedFunction<
                           Tests
 *********************************************************/
 
-let extensionSdkVersion = '1.0.0'
-let workspaceSdkVersion = '1.0.0'
+let extensionSdkVersion: string = '1.0.0'
+let workspaceSdkVersion: string | null = '1.0.0'
 
 describe('sdk', () => {
   beforeEach(() => {
@@ -30,8 +30,18 @@ describe('sdk', () => {
   afterEach(() => {
     getPackageVersionMock.mockReset()
   })
-  describe('When syncing the SDK version', () => {
-    describe('and the version of the workspace is the same than the one on the extension', () => {
+  describe('When syncing the @dcl/sdk version', () => {
+    describe('and the workspace does not use @dcl/sdk', () => {
+      beforeEach(() => {
+        extensionSdkVersion = '1.0.0'
+        workspaceSdkVersion = null
+      })
+      it('should not install the sdk', async () => {
+        await syncSdkVersion()
+        expect(npmInstallMock).not.toHaveBeenCalled()
+      })
+    })
+    describe('and the version of the workspace\'s @dcl/sdk is the same than the one on the extension', () => {
       beforeEach(() => {
         extensionSdkVersion = '1.0.0'
         workspaceSdkVersion = extensionSdkVersion
@@ -41,7 +51,7 @@ describe('sdk', () => {
         expect(npmInstallMock).not.toHaveBeenCalled()
       })
     })
-    describe('and the version of the workspace is the same than the one on the extension', () => {
+    describe('and the version of the workspace\'s @dcl/sdk is different to the one on the extension', () => {
       beforeEach(() => {
         extensionSdkVersion = '2.0.0'
         workspaceSdkVersion = '1.0.0'

--- a/src/modules/sdk.ts
+++ b/src/modules/sdk.ts
@@ -4,14 +4,18 @@ import { getPackageVersion } from './pkg'
 
 export async function syncSdkVersion() {
   const extensionSdkVersion = getPackageVersion('@dcl/sdk')
-  log(`Extension SDK version: ${extensionSdkVersion}`)
   const workspaceSdkVersion = getPackageVersion('@dcl/sdk', true)
-  log(`Workspace SDK version: ${workspaceSdkVersion}`)
+  if (!workspaceSdkVersion) {
+    // no need to sync if the workspace does not have a dependency on @dcl/sdk
+    return
+  }
   if (extensionSdkVersion !== workspaceSdkVersion) {
+    log(`Extension @dcl/sdk version: ${extensionSdkVersion}`)
+    log(`Workspace @dcl/sdk version: ${workspaceSdkVersion}`)
     log(
-      `Workspace SDK version is different than the extension\'s, installing @dcl/sdk@${extensionSdkVersion} into workspace...`
+      `Workspace @dcl/sdk version is different than the extension\'s, installing @dcl/sdk@${extensionSdkVersion} into workspace...`
     )
     await npmInstall(`@dcl/sdk@${extensionSdkVersion}`)
   }
-  log(`Workspace SDK version is up to date`)
+  log(`Workspace @dcl/sdk version is up to date`)
 }


### PR DESCRIPTION
This PR upgrades CLI to version 3.15.0 which fixes the issue with rented land, and also adds an NPS survey after successful deployments.

I also fixed an issue introduced by #67, we should link the SDK **only** on workspaces where `@dcl/sdk` is installed (aka only for SDK7 projects).