### PR TITLE
fix: GLTF preview with multiple files

### DIFF
--- a/src/views/gltf-preview/provider.ts
+++ b/src/views/gltf-preview/provider.ts
@@ -160,6 +160,7 @@ export class GLTFPreviewEditorProvider
         for (const webview of this.webviews.get(document.uri)) {
           this.postMessage(webview, GLFTPreviewExtensionMessageType.INIT, {
             file: document.documentData,
+            otherFiles: document.otherFiles,
             type: isEmote ? GLTFPreviewType.EMOTE : GLTFPreviewType.MODEL,
           })
         }

--- a/src/views/gltf-preview/types/extension-message.ts
+++ b/src/views/gltf-preview/types/extension-message.ts
@@ -10,6 +10,7 @@ export enum GLFTPreviewExtensionMessageType {
 export declare type GLFTPreviewExtensionMessagePayload = {
   [GLFTPreviewExtensionMessageType.INIT]: {
     file: Uint8Array
+    otherFiles: { name: string, data: Uint8Array }[]
     type: GLTFPreviewType
   }
 }

--- a/src/views/gltf-preview/webview/script.js
+++ b/src/views/gltf-preview/webview/script.js
@@ -26,10 +26,14 @@
         let blob
         let options = {}
         const file = new Blob([payload.file], { type: 'model/gltf-binary' })
+        const otherFiles = payload.otherFiles.map((file) => ({
+          key: file.name,
+          blob: new Blob([file.data]),
+        }))
 
         switch (payload.type) {
           case 'model': {
-            blob = toWearableWithBlobs(file)
+            blob = toWearableWithBlobs(file, otherFiles)
             options = {
               wheelZoom: 2,
               skin: '555555',
@@ -38,7 +42,7 @@
             break
           }
           case 'emote': {
-            blob = toEmoteWithBlobs(file)
+            blob = toEmoteWithBlobs(file, otherFiles)
             options = {
               profile: 'default',
               skin: '555555',
@@ -62,7 +66,7 @@
   })
 
   // Helpers to build wearable and emote with blobs
-  function toWearableWithBlobs(file, category = 'hat') {
+  function toWearableWithBlobs(file, otherFiles = [], category = 'hat') {
     return {
       id: 'some-id',
       name: '',
@@ -87,6 +91,7 @@
                 key: 'model.glb',
                 blob: file,
               },
+              ...otherFiles,
             ],
             overrideHides: [],
             overrideReplaces: [],
@@ -96,7 +101,7 @@
     }
   }
 
-  function toEmoteWithBlobs(file) {
+  function toEmoteWithBlobs(file, otherFiles = []) {
     return {
       id: 'some-id',
       name: '',
@@ -119,6 +124,7 @@
                 key: 'model.glb',
                 blob: file,
               },
+              ...otherFiles,
             ],
           },
         ],


### PR DESCRIPTION
This PR adds other files in the same directory to the contents of the GLTF preview, so if a GLTF loads some external files (like textures) they can be loaded. Without that change, the only files that could be previewed were GLB files were everything was bundled in a single file.

Fixes #71 