### PR TITLE
fix: white spaces on windows

### DIFF
--- a/src/modules/bin.spec.ts
+++ b/src/modules/bin.spec.ts
@@ -77,7 +77,7 @@ describe('bin', () => {
       bin('decentraland', 'dcl', ['start'])
       expect(spawn).toBeCalledWith(
         expect.any(String),
-        '/globalStorage/node',
+        '"/globalStorage/node"',
         expect.any(Array),
         expect.any(Object)
       )
@@ -159,7 +159,7 @@ describe('bin', () => {
         bin('decentraland', 'dcl')
         expect(spawn).toBeCalledWith(
           expect.any(String),
-          '/globalStorage\\ with\\ white\\ spaces/node',
+          '"/globalStorage with white spaces/node"',
           [expect.any(String)],
           expect.any(Object)
         )
@@ -180,7 +180,7 @@ describe('bin', () => {
         bin('decentraland', 'dcl')
         expect(spawn).toBeCalledWith(
           expect.any(String),
-          '/globalStorage/node.cmd',
+          '"/globalStorage/node.cmd"',
           [expect.any(String)],
           expect.any(Object)
         )

--- a/src/modules/bin.ts
+++ b/src/modules/bin.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import cmdShim from 'cmd-shim'
-import { escapeWhiteSpaces, getModuleBinPath, getNodeCmdPath } from './path'
+import { fixWhiteSpaces, getModuleBinPath, getNodeCmdPath } from './path'
 import { spawn, SpawnOptions } from './spawn'
 import { log } from './log'
 
@@ -18,7 +18,7 @@ export function bin(
   args: (string | undefined)[] = [],
   options: SpawnOptions = {}
 ) {
-  const node = escapeWhiteSpaces(getNodeCmdPath())
+  const node = fixWhiteSpaces(getNodeCmdPath())
   const bin = getModuleBinPath(moduleName, command)
   return spawn(
     args[0] ? `${command} ${args[0]}` : command,

--- a/src/modules/path.ts
+++ b/src/modules/path.ts
@@ -114,12 +114,12 @@ export function getNodeCmdPath() {
 }
 
 /**
- * Replace white spaces with "\ "
+ * Wrap path with double quotes to fix white spaces
  * @param p path to fix
  * @returns fixed path
  */
-export function escapeWhiteSpaces(p: string) {
-  return p.replace(/\s/g, '\\ ')
+export function fixWhiteSpaces(p: string) {
+  return `"${p}"`
 }
 
 /**


### PR DESCRIPTION
Fixes #73 

This PR changes the we handle the white spaces. Instead of scaping the white spaces with a blacklash (which does not work on Windows) now we wrap the whole path in double quotes, which works on both all platforms.