### PR TITLE
fix: include files from subfolders in GLTF preview

### DIFF
--- a/src/modules/path.ts
+++ b/src/modules/path.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import { getDistribution, isWindows } from './node'
 import { getPackageJson } from './pkg'
 import { log } from './log'
@@ -129,4 +130,26 @@ export function fixWhiteSpaces(p: string) {
 export function joinEnvPaths(...paths: (undefined | string)[]) {
   const separator = process.platform === 'win32' ? ';' : ':'
   return paths.filter((path): path is string => !!path).join(separator)
+}
+
+/**
+ * Returns all the paths for files in a directory, and in subdirectories
+ */
+
+export function getFilePaths(folder: string) {
+  const fileNames = fs.readdirSync(folder)
+  const filePaths: string[] = []
+  for (const fileName of fileNames) {
+    const filePath = path.resolve(folder, fileName)
+    const stats = fs.lstatSync(filePath)
+    if (stats.isDirectory()) {
+      const nestedFilePaths = getFilePaths(filePath)
+      for (const nestedFilePath of nestedFilePaths) {
+        filePaths.push(nestedFilePath)
+      }
+    } else if (stats.isFile()) {
+      filePaths.push(filePath)
+    }
+  }
+  return filePaths
 }


### PR DESCRIPTION
Fixes #79 
This PR adds a `getFilePaths` helper which returns all the file paths on a given folder, including all the file paths in subfolders. This is used for the GLTF preview and it fixes there issue caused by GLTF files that loaded files from subdirectory (before this PR we could only support GLTF files that loaded files from the same folder than the GLTF file).