### PR TITLE
fix: kill whole process tree when killing a child process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "rollbar": "^2.25.2",
         "semver": "^7.3.8",
         "tar-fs": "^2.1.1",
+        "tree-kill": "^1.2.2",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "unzip-stream": "^0.3.1",
@@ -11024,6 +11025,14 @@
       "integrity": "sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==",
       "optional": true
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.0.3",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
@@ -20102,6 +20111,11 @@
       "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
       "integrity": "sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==",
       "optional": true
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "ts-jest": {
       "version": "29.0.3",

--- a/package.json
+++ b/package.json
@@ -437,6 +437,7 @@
     "rollbar": "^2.25.2",
     "semver": "^7.3.8",
     "tar-fs": "^2.1.1",
+    "tree-kill": "^1.2.2",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "unzip-stream": "^0.3.1",

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -14,8 +14,7 @@ export function append(message: string) {
  * Append a message to the output in a new line
  */
 export function appendLine(message: string) {
-  const line = message + '\n'
-  output.append(line)
+  append(message + '\n')
 }
 
 /**

--- a/src/modules/spawn.spec.ts
+++ b/src/modules/spawn.spec.ts
@@ -9,6 +9,10 @@ import crossSpawn from 'cross-spawn'
 jest.mock('cross-spawn')
 const crossSpawnMock = crossSpawn as jest.MockedFunction<typeof crossSpawn>
 
+import treeKill from 'tree-kill'
+jest.mock('tree-kill')
+const treeKillMock = treeKill as jest.MockedFunction<typeof treeKill>
+
 import future, { IFuture } from 'fp-future'
 jest.mock('fp-future')
 const futureMock = future as jest.MockedFunction<typeof future<void>>
@@ -374,10 +378,10 @@ describe('When spawning a child process', () => {
     })
   })
   describe('and the child process is killed', () => {
-    it('should kill the child process with a signal 9', () => {
+    it('should kill the child process along with all its children', () => {
       const child = spawn('id', 'command')
       child.kill()
-      expect(childMock.kill).toHaveBeenCalledWith(9)
+      expect(treeKillMock).toHaveBeenCalledWith(child.process.pid)
     })
     describe('and the process can be gracefully killed', () => {
       beforeEach(() => {


### PR DESCRIPTION
Fixes #65 

This PR uses `tree-kill` to kill spawned child processes along with all their children. This avoid process leaks when closing the extension.