### PR TITLE
fix: windows path and distribution for arm64

### DIFF
--- a/src/modules/node.spec.ts
+++ b/src/modules/node.spec.ts
@@ -684,6 +684,16 @@ describe('node', () => {
           expect(getPlatform()).toBe('win-x86')
         })
       })
+      describe('and the architecture is arm64', () => {
+        beforeEach(() => {
+          Object.defineProperty(process, 'arch', {
+            value: 'arm64',
+          })
+        })
+        it('should return "win-x64"', () => {
+          expect(getPlatform()).toBe('win-x64')
+        })
+      })
       describe('and the architecture is not supported', () => {
         beforeEach(() => {
           Object.defineProperty(process, 'arch', {

--- a/src/modules/node.ts
+++ b/src/modules/node.ts
@@ -164,47 +164,45 @@ async function getAvailableVersions(page: number) {
  * @returns
  */
 export function getPlatform() {
-  let platform = ''
+  const platform: string[] = []
   switch (process.platform) {
     case 'darwin':
-      platform = 'darwin'
+      platform.push('darwin')
       break
     case 'win32':
-      platform = 'win'
+      platform.push('win')
       break
     case 'linux':
-      platform = 'linux'
+      platform.push('linux')
       break
     default:
       throw new Error(`Unsupported platform: "${process.platform}"`)
   }
 
-  platform += '-'
-
   switch (process.arch) {
     case 'arm64':
-      platform += 'arm64'
+      platform.push(platform[0] === 'win' ? 'x64' : 'arm64')
       break
     case 'arm':
-      platform += 'armv71'
+      platform.push('armv71')
       break
     case 'x64':
-      platform += 'x64'
+      platform.push('x64')
       break
     case 'ia32':
-      platform += 'x86'
+      platform.push('x86')
       break
     case 'ppc64':
-      platform += 'ppc64le'
+      platform.push('ppc64le')
       break
     case 's390x':
-      platform += 's390x'
+      platform.push('s390x')
       break
     default:
       throw new Error(`Unsupported architecture: "${process.arch}"`)
   }
 
-  return platform
+  return platform.join('-')
 }
 
 /**

--- a/src/modules/path.ts
+++ b/src/modules/path.ts
@@ -91,7 +91,7 @@ export function getModuleBinPath(moduleName: string, command: string) {
  * @returns The path to the node bin
  */
 export function getGlobalBinPath() {
-  return `${getGlobalStoragePath()}/bin`
+  return path.join(getGlobalStoragePath(), 'bin')
 }
 
 /**
@@ -101,8 +101,8 @@ export function getGlobalBinPath() {
 export function getNodeBinPath() {
   const distribution = getDistribution()
   const globalBinPath = getGlobalBinPath()
-  const pathToBin = isWindows(distribution) ? `node.exe` : `bin/node`
-  return `${globalBinPath}/${distribution}/${pathToBin}`
+  const pathToBin = isWindows(distribution) ? [`node.exe`] : [`bin`, `node`]
+  return path.join(globalBinPath, distribution, ...pathToBin)
 }
 
 /**


### PR DESCRIPTION
Fixes an issue when running windows through parallels (arch=arm64, platform=win32). Also it uses `path.join` instead of building the paths manually to avoid using the wrong slashes in windows.