### PR TITLE
feat: init an SDK7 project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "^7.0.6-4077117821.commit-60bf97f",
+        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -677,9 +677,10 @@
       }
     },
     "node_modules/@dcl/crdt": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-AP/k94gW/K99Pi4iUPoM9GQbC7poDuhWYzXP2YK3AFb3j9kCJJWhxFMhdasVa0BJbFl6x1juQDiPMHvI2oyNYA=="
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-8VTki4lxA0B3tIimPtvtgdyvGCvAjRbH3aEq3Qmd+nucLkg4ilOGQBJYynlctO5dgimeHB1Ca6zHQVispUq+bw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/crypto": {
       "version": "3.2.1",
@@ -692,9 +693,10 @@
       }
     },
     "node_modules/@dcl/dcl-rollup": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-gKMiiQKKufvn8VulcJkMvtYwB5VlM9GtH5Io3j8A326AwDevwADcRHM222m5jYH5AQJyzX3EwS8hKT00NlP2lA==",
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-gWeg5FYaQLY5DaLIP9HmglzUnlitoTbLxCBQWr91KlTPfhxukh0vc7vqsMXDQW1sQX4JAnks407jawkGeM9xEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/api-extractor": "^7.33.8",
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -715,13 +717,14 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-bk1OuRvrE8dSGQg+IohrOc1OP6prpZKAvjX05QYfFZtu3w78yR8v3M3O48C77xOJW732D9o7RZIB/ysncaRhhA==",
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-XkLIP5xTGYsLw2XV+NbAnDW9wScOeF+JtkRwmrHTg70jIGNdG+pGeZgYGxJ0lr0lEcz5VJksI3YbzvnDszCnRg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/crdt": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/crdt": "7.0.6-4085012314.commit-c9b83a3",
         "@dcl/js-runtime": "file:../js-runtime",
-        "@dcl/protocol": "1.0.0-4009547712.commit-472ea24"
+        "@dcl/protocol": "1.0.0-4075042272.commit-3585af9"
       }
     },
     "node_modules/@dcl/ecs-math": {
@@ -730,9 +733,9 @@
       "integrity": "sha512-PzIXiZLL3SLqYAam++tQ9de0bkscABKC2ItwhMj3SITTb1UykBMpC/fBRPz6HJzd4gIOb/asUiha41IKOl7xUA=="
     },
     "node_modules/@dcl/ecs/node_modules/@dcl/protocol": {
-      "version": "1.0.0-4009547712.commit-472ea24",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4009547712.commit-472ea24.tgz",
-      "integrity": "sha512-sKYR8SdY49VTR8yhPuPmvZrCNqV3JSkKgjkGGnEnc2n64SXtkTkoCJHwgZogwBCZVzshW9Jf0Urxr8zZGHJhFw==",
+      "version": "1.0.0-4075042272.commit-3585af9",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4075042272.commit-3585af9.tgz",
+      "integrity": "sha512-6awBPONXBiyYWXsh5UkJtk7hRV/VrX+mSm0+0LfRF2kwmZt+FT/E6K5hrATrT+HnSkP2ECNp1cn7/XkQjtY3Fg==",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
@@ -753,9 +756,10 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-uUI7HDl49ikvP9MN7sawS6DyYWwvyuUcuZP2SP4wYYrcLecKAyB/Z8mXs9u+18gr6bblzasy+qnXk1BJ8+nbmw=="
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-dsKcsBxhUB8d6ACJTE9GVnAifQ8/YwIgLWHoiys6e2bQdu4DCyPJdoy2NIdQ66V2Rr3W09FZkWvQ/N7UD1uTag==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -818,9 +822,10 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-W2FTu+o1kaXUFz0+eFlSn2fnZBM+QSw4iMvDvo8KVtZltAho2kW1mCysaeA89Rai8+8uygnK2rqqYj48DQcB5A==",
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-PIf/gmJK2h97hZMXHkBV4Cse5vPB+bP7chEDHGJ/HPFsQOFJsTRz2hFzp5ixQJzJ3K9tWvySd5aGAhshBg4+MA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -887,17 +892,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-eRgBo9JqmM2mpIB9DuPF3pCpbWSEwstW2o/OzImk0TH3Tx4eyNnTiYDPJztQCiTWfM2Q7JqutTiC1qcHjktbTA==",
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-ceVgCbK6UA+TKul1J93L3SvYxs12FFDt3dm3BXDUbkK+Pgjn140/yg5cj5L5vGjZO7GpO3RL1Xn+cebO5vaZIg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/dcl-rollup": "7.0.6-4077117821.commit-60bf97f",
-        "@dcl/ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/crdt": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/dcl-rollup": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
-        "@dcl/js-runtime": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/mini-comms": "1.0.0",
-        "@dcl/react-ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/schemas": "6.6.0",
         "@types/inquirer": "^8.2.5",
         "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",
@@ -10682,9 +10689,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
-      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.13.0.tgz",
+      "integrity": "sha512-HJwQtrXAc0AmyDohTJ/2c+Bx/sWPScJLlAUJ1kuD7rAkCro8Cr2SnVB2gVYBiSLxpgD2kZ24jbyXtG++GumrYQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12622,9 +12629,9 @@
       }
     },
     "@dcl/crdt": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-AP/k94gW/K99Pi4iUPoM9GQbC7poDuhWYzXP2YK3AFb3j9kCJJWhxFMhdasVa0BJbFl6x1juQDiPMHvI2oyNYA=="
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-8VTki4lxA0B3tIimPtvtgdyvGCvAjRbH3aEq3Qmd+nucLkg4ilOGQBJYynlctO5dgimeHB1Ca6zHQVispUq+bw=="
     },
     "@dcl/crypto": {
       "version": "3.2.1",
@@ -12637,9 +12644,8 @@
       }
     },
     "@dcl/dcl-rollup": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-gKMiiQKKufvn8VulcJkMvtYwB5VlM9GtH5Io3j8A326AwDevwADcRHM222m5jYH5AQJyzX3EwS8hKT00NlP2lA==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-gWeg5FYaQLY5DaLIP9HmglzUnlitoTbLxCBQWr91KlTPfhxukh0vc7vqsMXDQW1sQX4JAnks407jawkGeM9xEQ==",
       "requires": {
         "@microsoft/api-extractor": "^7.33.8",
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -12657,18 +12663,18 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "integrity": "sha512-bk1OuRvrE8dSGQg+IohrOc1OP6prpZKAvjX05QYfFZtu3w78yR8v3M3O48C77xOJW732D9o7RZIB/ysncaRhhA==",
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "integrity": "sha512-XkLIP5xTGYsLw2XV+NbAnDW9wScOeF+JtkRwmrHTg70jIGNdG+pGeZgYGxJ0lr0lEcz5VJksI3YbzvnDszCnRg==",
       "requires": {
-        "@dcl/crdt": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/crdt": "7.0.6-4085012314.commit-c9b83a3",
         "@dcl/js-runtime": "file:../js-runtime",
-        "@dcl/protocol": "1.0.0-4009547712.commit-472ea24"
+        "@dcl/protocol": "1.0.0-4075042272.commit-3585af9"
       },
       "dependencies": {
         "@dcl/protocol": {
-          "version": "1.0.0-4009547712.commit-472ea24",
-          "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4009547712.commit-472ea24.tgz",
-          "integrity": "sha512-sKYR8SdY49VTR8yhPuPmvZrCNqV3JSkKgjkGGnEnc2n64SXtkTkoCJHwgZogwBCZVzshW9Jf0Urxr8zZGHJhFw==",
+          "version": "1.0.0-4075042272.commit-3585af9",
+          "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4075042272.commit-3585af9.tgz",
+          "integrity": "sha512-6awBPONXBiyYWXsh5UkJtk7hRV/VrX+mSm0+0LfRF2kwmZt+FT/E6K5hrATrT+HnSkP2ECNp1cn7/XkQjtY3Fg==",
           "requires": {
             "ts-proto": "^1.126.1"
           }
@@ -12696,8 +12702,8 @@
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "integrity": "sha512-uUI7HDl49ikvP9MN7sawS6DyYWwvyuUcuZP2SP4wYYrcLecKAyB/Z8mXs9u+18gr6bblzasy+qnXk1BJ8+nbmw=="
+      "version": "7.0.6-4085012314.commit-c9b83a3",
+      "integrity": "sha512-dsKcsBxhUB8d6ACJTE9GVnAifQ8/YwIgLWHoiys6e2bQdu4DCyPJdoy2NIdQ66V2Rr3W09FZkWvQ/N7UD1uTag=="
     },
     "@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -12758,9 +12764,8 @@
       }
     },
     "@dcl/react-ecs": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-W2FTu+o1kaXUFz0+eFlSn2fnZBM+QSw4iMvDvo8KVtZltAho2kW1mCysaeA89Rai8+8uygnK2rqqYj48DQcB5A==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-PIf/gmJK2h97hZMXHkBV4Cse5vPB+bP7chEDHGJ/HPFsQOFJsTRz2hFzp5ixQJzJ3K9tWvySd5aGAhshBg4+MA==",
       "requires": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -12820,17 +12825,17 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.0.6-4077117821.commit-60bf97f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4077117821.commit-60bf97f.tgz",
-      "integrity": "sha512-eRgBo9JqmM2mpIB9DuPF3pCpbWSEwstW2o/OzImk0TH3Tx4eyNnTiYDPJztQCiTWfM2Q7JqutTiC1qcHjktbTA==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
+      "integrity": "sha512-ceVgCbK6UA+TKul1J93L3SvYxs12FFDt3dm3BXDUbkK+Pgjn140/yg5cj5L5vGjZO7GpO3RL1Xn+cebO5vaZIg==",
       "requires": {
-        "@dcl/dcl-rollup": "7.0.6-4077117821.commit-60bf97f",
-        "@dcl/ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/crdt": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/dcl-rollup": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
-        "@dcl/js-runtime": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/mini-comms": "1.0.0",
-        "@dcl/react-ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
         "@dcl/schemas": "6.6.0",
         "@types/inquirer": "^8.2.5",
         "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",
@@ -20148,9 +20153,9 @@
       }
     },
     "rollup": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
-      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.13.0.tgz",
+      "integrity": "sha512-HJwQtrXAc0AmyDohTJ/2c+Bx/sWPScJLlAUJ1kuD7rAkCro8Cr2SnVB2gVYBiSLxpgD2kZ24jbyXtG++GumrYQ==",
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/sdk": "^7.0.6-4085247017.commit-f004317",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -677,10 +677,9 @@
       }
     },
     "node_modules/@dcl/crdt": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-8VTki4lxA0B3tIimPtvtgdyvGCvAjRbH3aEq3Qmd+nucLkg4ilOGQBJYynlctO5dgimeHB1Ca6zHQVispUq+bw==",
-      "license": "Apache-2.0"
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-ZX6N2fzFkszwHIwAGPLfWmQxVbmu2Kpfk25err0reL7Jb42VcO20Ny2QFN/MInasXEpQVq/6ChvWYW/dHYl34Q=="
     },
     "node_modules/@dcl/crypto": {
       "version": "3.2.1",
@@ -693,10 +692,9 @@
       }
     },
     "node_modules/@dcl/dcl-rollup": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-gWeg5FYaQLY5DaLIP9HmglzUnlitoTbLxCBQWr91KlTPfhxukh0vc7vqsMXDQW1sQX4JAnks407jawkGeM9xEQ==",
-      "license": "Apache-2.0",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-3OtRWsB7O7QL5OUr/R0dNdBtqF8mSsWZh74i6WDL5s8BAvTDuyKPHdR4vSwXBwQ5deu9nfmbgFUfh+HX9LEpRw==",
       "dependencies": {
         "@microsoft/api-extractor": "^7.33.8",
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -717,12 +715,11 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-XkLIP5xTGYsLw2XV+NbAnDW9wScOeF+JtkRwmrHTg70jIGNdG+pGeZgYGxJ0lr0lEcz5VJksI3YbzvnDszCnRg==",
-      "license": "Apache-2.0",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-eYM5V2HlqDDKIa7iaHVeeRnxyYLoarn2jEg2VyGwafdH7vEAIQMb4qU9rlH0eWN/ERzSy+Zo/og4YOFdHtsrpw==",
       "dependencies": {
-        "@dcl/crdt": "7.0.6-4085012314.commit-c9b83a3",
+        "@dcl/crdt": "7.0.6-4085247017.commit-f004317",
         "@dcl/js-runtime": "file:../js-runtime",
         "@dcl/protocol": "1.0.0-4075042272.commit-3585af9"
       }
@@ -756,10 +753,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-dsKcsBxhUB8d6ACJTE9GVnAifQ8/YwIgLWHoiys6e2bQdu4DCyPJdoy2NIdQ66V2Rr3W09FZkWvQ/N7UD1uTag==",
-      "license": "Apache-2.0"
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-Wf4FFvngiw/yh9ZvxIWRUhrwfe9zFCm3umKMSE5yCYBOVRUxzcsx/CpyqPxgPLX+1oB5D8AlQXxvn3Hc8vpePA=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -822,10 +818,9 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-PIf/gmJK2h97hZMXHkBV4Cse5vPB+bP7chEDHGJ/HPFsQOFJsTRz2hFzp5ixQJzJ3K9tWvySd5aGAhshBg4+MA==",
-      "license": "Apache-2.0",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-R3MnPnhH0DAwtZ4rRqBd/8bSHIUOe0AeQdrEofebAjDjgU5pATCHqitj4MV7wN4fJ36zERqpH99Lu6NUogBp1w==",
       "dependencies": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -892,19 +887,17 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-ceVgCbK6UA+TKul1J93L3SvYxs12FFDt3dm3BXDUbkK+Pgjn140/yg5cj5L5vGjZO7GpO3RL1Xn+cebO5vaZIg==",
-      "license": "Apache-2.0",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-j2vUc4iKFnQlhdoikjrUmVmHUmQ+18LfSUddxJ5suYhRA3WyfrVptuncmV6tLqIcuAUtJ8nkCsyD3FmZoO7B7Q==",
       "dependencies": {
-        "@dcl/crdt": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
-        "@dcl/dcl-rollup": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
-        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/dcl-rollup": "7.0.6-4085247017.commit-f004317",
+        "@dcl/ecs": "7.0.6-4085247017.commit-f004317",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
-        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/js-runtime": "7.0.6-4085247017.commit-f004317",
         "@dcl/mini-comms": "1.0.0",
-        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/react-ecs": "7.0.6-4085247017.commit-f004317",
         "@dcl/schemas": "6.6.0",
         "@types/inquirer": "^8.2.5",
         "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",
@@ -12629,9 +12622,9 @@
       }
     },
     "@dcl/crdt": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-8VTki4lxA0B3tIimPtvtgdyvGCvAjRbH3aEq3Qmd+nucLkg4ilOGQBJYynlctO5dgimeHB1Ca6zHQVispUq+bw=="
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-ZX6N2fzFkszwHIwAGPLfWmQxVbmu2Kpfk25err0reL7Jb42VcO20Ny2QFN/MInasXEpQVq/6ChvWYW/dHYl34Q=="
     },
     "@dcl/crypto": {
       "version": "3.2.1",
@@ -12644,8 +12637,9 @@
       }
     },
     "@dcl/dcl-rollup": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-gWeg5FYaQLY5DaLIP9HmglzUnlitoTbLxCBQWr91KlTPfhxukh0vc7vqsMXDQW1sQX4JAnks407jawkGeM9xEQ==",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-3OtRWsB7O7QL5OUr/R0dNdBtqF8mSsWZh74i6WDL5s8BAvTDuyKPHdR4vSwXBwQ5deu9nfmbgFUfh+HX9LEpRw==",
       "requires": {
         "@microsoft/api-extractor": "^7.33.8",
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -12663,10 +12657,10 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "integrity": "sha512-XkLIP5xTGYsLw2XV+NbAnDW9wScOeF+JtkRwmrHTg70jIGNdG+pGeZgYGxJ0lr0lEcz5VJksI3YbzvnDszCnRg==",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "integrity": "sha512-eYM5V2HlqDDKIa7iaHVeeRnxyYLoarn2jEg2VyGwafdH7vEAIQMb4qU9rlH0eWN/ERzSy+Zo/og4YOFdHtsrpw==",
       "requires": {
-        "@dcl/crdt": "7.0.6-4085012314.commit-c9b83a3",
+        "@dcl/crdt": "7.0.6-4085247017.commit-f004317",
         "@dcl/js-runtime": "file:../js-runtime",
         "@dcl/protocol": "1.0.0-4075042272.commit-3585af9"
       },
@@ -12702,8 +12696,8 @@
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.0.6-4085012314.commit-c9b83a3",
-      "integrity": "sha512-dsKcsBxhUB8d6ACJTE9GVnAifQ8/YwIgLWHoiys6e2bQdu4DCyPJdoy2NIdQ66V2Rr3W09FZkWvQ/N7UD1uTag=="
+      "version": "7.0.6-4085247017.commit-f004317",
+      "integrity": "sha512-Wf4FFvngiw/yh9ZvxIWRUhrwfe9zFCm3umKMSE5yCYBOVRUxzcsx/CpyqPxgPLX+1oB5D8AlQXxvn3Hc8vpePA=="
     },
     "@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -12764,8 +12758,9 @@
       }
     },
     "@dcl/react-ecs": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-PIf/gmJK2h97hZMXHkBV4Cse5vPB+bP7chEDHGJ/HPFsQOFJsTRz2hFzp5ixQJzJ3K9tWvySd5aGAhshBg4+MA==",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-R3MnPnhH0DAwtZ4rRqBd/8bSHIUOe0AeQdrEofebAjDjgU5pATCHqitj4MV7wN4fJ36zERqpH99Lu6NUogBp1w==",
       "requires": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -12825,17 +12820,17 @@
       }
     },
     "@dcl/sdk": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
-      "integrity": "sha512-ceVgCbK6UA+TKul1J93L3SvYxs12FFDt3dm3BXDUbkK+Pgjn140/yg5cj5L5vGjZO7GpO3RL1Xn+cebO5vaZIg==",
+      "version": "7.0.6-4085247017.commit-f004317",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4085247017.commit-f004317.tgz",
+      "integrity": "sha512-j2vUc4iKFnQlhdoikjrUmVmHUmQ+18LfSUddxJ5suYhRA3WyfrVptuncmV6tLqIcuAUtJ8nkCsyD3FmZoO7B7Q==",
       "requires": {
-        "@dcl/crdt": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-crdt/dcl-crdt-7.0.6-4085012314.commit-c9b83a3.tgz",
-        "@dcl/dcl-rollup": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/dcl-rollup/dcl-dcl-rollup-7.0.6-4085012314.commit-c9b83a3.tgz",
-        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/ecs/dcl-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/dcl-rollup": "7.0.6-4085247017.commit-f004317",
+        "@dcl/ecs": "7.0.6-4085247017.commit-f004317",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
         "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
-        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/js-runtime/dcl-js-runtime-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/js-runtime": "7.0.6-4085247017.commit-f004317",
         "@dcl/mini-comms": "1.0.0",
-        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/@dcl/react-ecs/dcl-react-ecs-7.0.6-4085012314.commit-c9b83a3.tgz",
+        "@dcl/react-ecs": "7.0.6-4085247017.commit-f004317",
         "@dcl/schemas": "6.6.0",
         "@types/inquirer": "^8.2.5",
         "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dcl/schemas": "^5.18.1",
-        "@dcl/sdk": "^7.0.5",
+        "@dcl/sdk": "^7.0.6-4077117821.commit-60bf97f",
         "@dcl/wearable-preview": "^1.14.0",
         "@types/analytics-node": "^3.1.9",
         "@types/cmd-shim": "^5.0.0",
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@dcl/crdt": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.5.tgz",
-      "integrity": "sha512-Z9WsucWonpwedQapqPksU7rUUEeaAt9uD2urXhqE7mWNZieYGRNGc+8JBuXlyqINVR9b5UNQiSv5uZssGhPMDQ=="
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-AP/k94gW/K99Pi4iUPoM9GQbC7poDuhWYzXP2YK3AFb3j9kCJJWhxFMhdasVa0BJbFl6x1juQDiPMHvI2oyNYA=="
     },
     "node_modules/@dcl/crypto": {
       "version": "3.2.1",
@@ -692,35 +692,36 @@
       }
     },
     "node_modules/@dcl/dcl-rollup": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.5.tgz",
-      "integrity": "sha512-rVDqQLeeUhs2nM08LZZ/aIx6qf0vFTFbFNCu3gbo1hgZDjDsrRae6li6n2VTH6KBF8/QPbABoPPGOYCuicNamQ==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-gKMiiQKKufvn8VulcJkMvtYwB5VlM9GtH5Io3j8A326AwDevwADcRHM222m5jYH5AQJyzX3EwS8hKT00NlP2lA==",
       "dependencies": {
-        "@rollup/plugin-commonjs": "^23.0.2",
+        "@microsoft/api-extractor": "^7.33.8",
+        "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "@rollup/plugin-replace": "^5.0.1",
-        "@rollup/plugin-terser": "^0.1.0",
-        "@rollup/plugin-typescript": "^9.0.2",
+        "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-terser": "^0.4.0",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "arg": "^5.0.2",
         "colorette": "^2.0.19",
         "fp-future": "^1.0.1",
         "glob": "^7.1.7",
-        "rollup": "^3.4.0",
+        "rollup": "^3.10.1",
         "rollup-plugin-analyzer": "^4.0.0",
-        "rollup-plugin-api-extractor": "^0.2.5",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.4"
       },
       "bin": {
         "build-ecs": "index.js"
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.0.5.tgz",
-      "integrity": "sha512-ed/pjdg9HD+BfcqMMH+Mf0U23fN0JHL7AmNFCChK8RIamgiZTkbr4wxs9bR2tb3kydyWW9kXi2Uaz1/Md42bbA==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-bk1OuRvrE8dSGQg+IohrOc1OP6prpZKAvjX05QYfFZtu3w78yR8v3M3O48C77xOJW732D9o7RZIB/ysncaRhhA==",
       "dependencies": {
-        "@dcl/crdt": "7.0.5",
+        "@dcl/crdt": "7.0.6-4077117821.commit-60bf97f",
         "@dcl/js-runtime": "file:../js-runtime",
-        "@dcl/protocol": "^1.0.0-3603890942.commit-44633cf"
+        "@dcl/protocol": "1.0.0-4009547712.commit-472ea24"
       }
     },
     "node_modules/@dcl/ecs-math": {
@@ -729,12 +730,17 @@
       "integrity": "sha512-PzIXiZLL3SLqYAam++tQ9de0bkscABKC2ItwhMj3SITTb1UykBMpC/fBRPz6HJzd4gIOb/asUiha41IKOl7xUA=="
     },
     "node_modules/@dcl/ecs/node_modules/@dcl/protocol": {
-      "version": "1.0.0-3840796783.commit-1c7238d",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3840796783.commit-1c7238d.tgz",
-      "integrity": "sha512-MZ8AGsg9yEQ265KeQnX20tD12xnPWDFM3eRRukbeKgHp1BbHIXGIoN5hyvPyOQfLrOAZt2GUJoxMhqkJo5OsBA==",
+      "version": "1.0.0-4009547712.commit-472ea24",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4009547712.commit-472ea24.tgz",
+      "integrity": "sha512-sKYR8SdY49VTR8yhPuPmvZrCNqV3JSkKgjkGGnEnc2n64SXtkTkoCJHwgZogwBCZVzshW9Jf0Urxr8zZGHJhFw==",
       "dependencies": {
         "ts-proto": "^1.126.1"
       }
+    },
+    "node_modules/@dcl/explorer": {
+      "version": "1.0.74928-20230130201703.commit-6da8317",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.74928-20230130201703.commit-6da8317.tgz",
+      "integrity": "sha512-YduoKnrM/5yXmIXBrwGpwcJez+cHEAXQeDhRWVdNdyLHqwu76tFZRIm33jiq77OlZWRcBvkrG/RKxPC+hFMYXw=="
     },
     "node_modules/@dcl/hashing": {
       "version": "1.1.0",
@@ -747,9 +753,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.0.5.tgz",
-      "integrity": "sha512-Ih+tSiPrMqQzrjm0R9kgs62w5h/+DGZ5IKZ9Y9XO8uA8YsoUoMpO+NIKyPHRpcvGFrKIzM02CS9gPGbpsCob/A=="
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-uUI7HDl49ikvP9MN7sawS6DyYWwvyuUcuZP2SP4wYYrcLecKAyB/Z8mXs9u+18gr6bblzasy+qnXk1BJ8+nbmw=="
     },
     "node_modules/@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -812,9 +818,9 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.5.tgz",
-      "integrity": "sha512-r9yLXhWZCpm/unO2u3r423IvoYgFWeG/PcyC+iyUvuuRQZY1BivV/YyVwR8M2KuY37jXVnmV5apV8TaoFjAi8A==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-W2FTu+o1kaXUFz0+eFlSn2fnZBM+QSw4iMvDvo8KVtZltAho2kW1mCysaeA89Rai8+8uygnK2rqqYj48DQcB5A==",
       "dependencies": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -881,28 +887,227 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.5.tgz",
-      "integrity": "sha512-zKEbSS1yp+hQXRGNH4H+6Ix+4qvm9RW72uljXhCAc9S023Yeyro+Goz7CWyB6EoaECPeJagQHlMECLurlmNlLw==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-eRgBo9JqmM2mpIB9DuPF3pCpbWSEwstW2o/OzImk0TH3Tx4eyNnTiYDPJztQCiTWfM2Q7JqutTiC1qcHjktbTA==",
       "dependencies": {
-        "@dcl/dcl-rollup": "7.0.5",
-        "@dcl/ecs": "7.0.5",
+        "@dcl/dcl-rollup": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/ecs": "7.0.6-4077117821.commit-60bf97f",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
-        "@dcl/js-runtime": "7.0.5",
-        "@dcl/kernel": "2.0.0-3640389337.commit-b563bb9",
-        "@dcl/react-ecs": "7.0.5",
-        "@dcl/unity-renderer": "1.0.66458-20221207172857.commit-1a83854"
+        "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
+        "@dcl/js-runtime": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/mini-comms": "1.0.0",
+        "@dcl/react-ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/schemas": "6.6.0",
+        "@types/inquirer": "^8.2.5",
+        "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",
+        "@well-known-components/http-server": "^1.1.6-20220927190058.commit-2dfb235",
+        "@well-known-components/logger": "^3.0.0",
+        "@well-known-components/metrics": "^2.0.1-20220909150423.commit-8f7e5bc",
+        "arg": "5.0.2",
+        "extract-zip": "2.0.1",
+        "inquirer": "^8.2.5",
+        "node-fetch": "^2.6.8",
+        "open": "^8.4.0",
+        "ora": "6.1.2",
+        "portfinder": "^1.0.32",
+        "undici": "^5.14.0"
+      },
+      "bin": {
+        "sdk-commands": "cli/index.js"
       }
     },
-    "node_modules/@dcl/sdk/node_modules/@dcl/kernel": {
-      "version": "2.0.0-3640389337.commit-b563bb9",
-      "resolved": "https://registry.npmjs.org/@dcl/kernel/-/kernel-2.0.0-3640389337.commit-b563bb9.tgz",
-      "integrity": "sha512-jKrSj8ev08BkJRYqtQhABJ9Xs/kXcmPpTMtsQf6hyPb8fqnsrBjHEFseM9/4LLZdRRydwFbADDGdOvRkjXPFmw=="
+    "node_modules/@dcl/sdk/node_modules/@dcl/schemas": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.6.0.tgz",
+      "integrity": "sha512-8+y8NBeGq/A6AMr3FOPsmCY7ru4YUbpJkFKzmJe1dQH9Zq61/iHveJIamHJca5RCrB3D1oFPFs0KP6yWnMKElg==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0"
+      }
     },
-    "node_modules/@dcl/sdk/node_modules/@dcl/unity-renderer": {
-      "version": "1.0.66458-20221207172857.commit-1a83854",
-      "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.66458-20221207172857.commit-1a83854.tgz",
-      "integrity": "sha512-ZBiT5Yat2ePifMGrpdu2tqh0fyHM5lVNufEBxiPjqX1Q28uuMv5zsScCK4FnSR4VBcPli1SsU+ONWl7bIdYm3w=="
+    "node_modules/@dcl/sdk/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@dcl/sdk/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/ora": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+      "dependencies": {
+        "bl": "^5.0.0",
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dcl/sdk/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/@dcl/unity-renderer": {
       "version": "1.0.62831-20221116134138.commit-7908797",
@@ -1322,19 +1527,19 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.33.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.7.tgz",
-      "integrity": "sha512-fQT2v/j/55DhvMFiopLtth66E7xTFNhnumMKgKY14SaG6qU/V1W0e4nOAgbA+SmLakQjAd1Evu06ofaVaxBPbA==",
+      "version": "7.34.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.2.tgz",
+      "integrity": "sha512-oREyUU7p3JgjrqapJxEHe83gA1SXOWgaA4XCiY9PvsiLkgGHtn2ibTRgw9GCI/4kZzcb+OQv5waUDxsnQSKfwQ==",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.25.3",
+        "@microsoft/api-extractor-model": "7.26.2",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3",
+        "@rushstack/node-core-library": "3.55.0",
         "@rushstack/rig-package": "0.3.17",
         "@rushstack/ts-command-line": "4.13.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
-        "resolve": "~1.17.0",
+        "resolve": "~1.22.1",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
         "typescript": "~4.8.4"
@@ -1344,24 +1549,141 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.25.3.tgz",
-      "integrity": "sha512-WWxBUq77p2iZ+5VF7Nmrm3y/UtqCh5bYV8ii3khwq3w99+fXWpvfsAhgSLsC7k8XDQc6De4ssMxH6He/qe1pzg==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.2.tgz",
+      "integrity": "sha512-V9tTHbYTNelTrNDXBzeDlszq29nQcjJdP6s27QJiATbqSRjEbKTeztlSVsCRHL2Wkkv5IN5jT4xkYjnFFPbK0A==",
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3"
+        "@rushstack/node-core-library": "3.55.0"
       }
     },
-    "node_modules/@microsoft/api-extractor/node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+    "node_modules/@microsoft/api-extractor-model/node_modules/@rushstack/node-core-library": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.55.0.tgz",
+      "integrity": "sha512-6lSel8w3DeGaD/JCKw64wfezEBijlCQlMwBoYg9Ci5VPy+dZ+FpBkIBrY8mi3Ge4xNzr4gyTbQ5XEt0QP1Kv/w==",
       "dependencies": {
-        "path-parse": "^1.0.6"
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "peerDependencies": {
+        "@types/node": "^14.18.36"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/@types/node": {
+      "version": "14.18.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/@rushstack/node-core-library": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.55.0.tgz",
+      "integrity": "sha512-6lSel8w3DeGaD/JCKw64wfezEBijlCQlMwBoYg9Ci5VPy+dZ+FpBkIBrY8mi3Ge4xNzr4gyTbQ5XEt0QP1Kv/w==",
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "^14.18.36"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/@types/node": {
+      "version": "14.18.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -1474,9 +1796,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "23.0.7",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.7.tgz",
-      "integrity": "sha512-hsSD5Qzyuat/swzrExGG5l7EuIlPhwTsT7KwKbSCQzIcJWjRxiimi/0tyMYY2bByitNb3i1p+6JWEDGa0NvT0Q==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
+      "integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "commondir": "^1.0.1",
@@ -1506,9 +1828,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1524,9 +1846,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1579,10 +1901,12 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
-      "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
       "dependencies": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
         "terser": "^5.15.1"
       },
       "engines": {
@@ -1598,9 +1922,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-9.0.2.tgz",
-      "integrity": "sha512-/sS93vmHUMjzDUsl5scNQr1mUlNE1QjBBvOhmRwJCH8k2RRhDIm3c977B3wdu3t3Ap17W6dDeXP3hj1P1Un1bA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "resolve": "^1.22.1"
@@ -1641,66 +1965,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "3.53.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.3.tgz",
-      "integrity": "sha512-H0+T5koi5MFhJUd5ND3dI3bwLhvlABetARl78L3lWftJVQEPyzcgTStvTTRiIM5mCltyTM8VYm6BuCtNUuxD0Q==",
-      "dependencies": {
-        "@types/node": "12.20.24",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "z-schema": "~5.0.2"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/@types/node": {
-      "version": "12.20.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dependencies": {
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/@rushstack/rig-package": {
@@ -2043,6 +2307,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/inquirer": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QXlzybid60YtAwfgG3cpykptRYUx2KomzNutMlWsQC64J/WG/gQSl+P4w7A21sGN0VIxRVava4rgnT7FQmFCdg==",
+      "dependencies": {
+        "@types/through": "*"
+      }
+    },
     "node_modules/@types/is-running": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-running/-/is-running-2.1.0.tgz",
@@ -2203,6 +2475,14 @@
       "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
       "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2974,6 +3254,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -5259,9 +5550,9 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/inquirer": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
-      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -5386,9 +5677,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-builtin-module": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },
@@ -10052,6 +10343,14 @@
         "rabin-wasm": "cli/bin.js"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10383,9 +10682,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
-      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
+      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10403,19 +10702,6 @@
       "integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-api-extractor": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-api-extractor/-/rollup-plugin-api-extractor-0.2.5.tgz",
-      "integrity": "sha512-oWG57yqB6n/xn2egrbiOFjgKjIt/GCwbcdQHaDDM5s26RvwBfckCIokCP3reZCS1OQnINw8NOPcJNarTjef8rA==",
-      "dependencies": {
-        "@microsoft/api-extractor": "^7.19.0"
-      },
-      "peerDependencies": {
-        "@microsoft/api-extractor": ">=7.19.0",
-        "rollup": ">=2.63.0",
-        "tslib": "*"
       }
     },
     "node_modules/run-async": {
@@ -10526,6 +10812,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
@@ -10641,6 +10935,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw=="
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10710,6 +11009,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -11258,10 +11565,10 @@
       "resolved": "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.1.tgz",
       "integrity": "sha512-762imXO+myoSDHD9+YxUfSmfT0yGH1j+3s9UJ6uqKkOYIwHH6/gsFo67ZoST0Ey/RSoaps1zGu1N+eiuuCxfeg=="
     },
-    "node_modules/servercript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11289,6 +11596,17 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
+      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -11414,9 +11732,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -11821,9 +12139,9 @@
       }
     },
     "node_modules/z-schema/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "optional": true,
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -12304,9 +12622,9 @@
       }
     },
     "@dcl/crdt": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.5.tgz",
-      "integrity": "sha512-Z9WsucWonpwedQapqPksU7rUUEeaAt9uD2urXhqE7mWNZieYGRNGc+8JBuXlyqINVR9b5UNQiSv5uZssGhPMDQ=="
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-AP/k94gW/K99Pi4iUPoM9GQbC7poDuhWYzXP2YK3AFb3j9kCJJWhxFMhdasVa0BJbFl6x1juQDiPMHvI2oyNYA=="
     },
     "@dcl/crypto": {
       "version": "3.2.1",
@@ -12319,37 +12637,38 @@
       }
     },
     "@dcl/dcl-rollup": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.5.tgz",
-      "integrity": "sha512-rVDqQLeeUhs2nM08LZZ/aIx6qf0vFTFbFNCu3gbo1hgZDjDsrRae6li6n2VTH6KBF8/QPbABoPPGOYCuicNamQ==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/dcl-rollup/-/dcl-rollup-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-gKMiiQKKufvn8VulcJkMvtYwB5VlM9GtH5Io3j8A326AwDevwADcRHM222m5jYH5AQJyzX3EwS8hKT00NlP2lA==",
       "requires": {
-        "@rollup/plugin-commonjs": "^23.0.2",
+        "@microsoft/api-extractor": "^7.33.8",
+        "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "@rollup/plugin-replace": "^5.0.1",
-        "@rollup/plugin-terser": "^0.1.0",
-        "@rollup/plugin-typescript": "^9.0.2",
+        "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-terser": "^0.4.0",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "arg": "^5.0.2",
         "colorette": "^2.0.19",
         "fp-future": "^1.0.1",
         "glob": "^7.1.7",
-        "rollup": "^3.4.0",
+        "rollup": "^3.10.1",
         "rollup-plugin-analyzer": "^4.0.0",
-        "rollup-plugin-api-extractor": "^0.2.5",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.4"
       }
     },
     "@dcl/ecs": {
-      "version": "7.0.5",
-      "integrity": "sha512-ed/pjdg9HD+BfcqMMH+Mf0U23fN0JHL7AmNFCChK8RIamgiZTkbr4wxs9bR2tb3kydyWW9kXi2Uaz1/Md42bbA==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "integrity": "sha512-bk1OuRvrE8dSGQg+IohrOc1OP6prpZKAvjX05QYfFZtu3w78yR8v3M3O48C77xOJW732D9o7RZIB/ysncaRhhA==",
       "requires": {
-        "@dcl/crdt": "7.0.5",
+        "@dcl/crdt": "7.0.6-4077117821.commit-60bf97f",
         "@dcl/js-runtime": "file:../js-runtime",
-        "@dcl/protocol": "^1.0.0-3603890942.commit-44633cf"
+        "@dcl/protocol": "1.0.0-4009547712.commit-472ea24"
       },
       "dependencies": {
         "@dcl/protocol": {
-          "version": "1.0.0-3840796783.commit-1c7238d",
-          "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-3840796783.commit-1c7238d.tgz",
-          "integrity": "sha512-MZ8AGsg9yEQ265KeQnX20tD12xnPWDFM3eRRukbeKgHp1BbHIXGIoN5hyvPyOQfLrOAZt2GUJoxMhqkJo5OsBA==",
+          "version": "1.0.0-4009547712.commit-472ea24",
+          "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-4009547712.commit-472ea24.tgz",
+          "integrity": "sha512-sKYR8SdY49VTR8yhPuPmvZrCNqV3JSkKgjkGGnEnc2n64SXtkTkoCJHwgZogwBCZVzshW9Jf0Urxr8zZGHJhFw==",
           "requires": {
             "ts-proto": "^1.126.1"
           }
@@ -12360,6 +12679,11 @@
       "version": "2.0.1-20221129185242.commit-40495c1",
       "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-2.0.1-20221129185242.commit-40495c1.tgz",
       "integrity": "sha512-PzIXiZLL3SLqYAam++tQ9de0bkscABKC2ItwhMj3SITTb1UykBMpC/fBRPz6HJzd4gIOb/asUiha41IKOl7xUA=="
+    },
+    "@dcl/explorer": {
+      "version": "1.0.74928-20230130201703.commit-6da8317",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.74928-20230130201703.commit-6da8317.tgz",
+      "integrity": "sha512-YduoKnrM/5yXmIXBrwGpwcJez+cHEAXQeDhRWVdNdyLHqwu76tFZRIm33jiq77OlZWRcBvkrG/RKxPC+hFMYXw=="
     },
     "@dcl/hashing": {
       "version": "1.1.0",
@@ -12372,8 +12696,8 @@
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.0.5",
-      "integrity": "sha512-Ih+tSiPrMqQzrjm0R9kgs62w5h/+DGZ5IKZ9Y9XO8uA8YsoUoMpO+NIKyPHRpcvGFrKIzM02CS9gPGbpsCob/A=="
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "integrity": "sha512-uUI7HDl49ikvP9MN7sawS6DyYWwvyuUcuZP2SP4wYYrcLecKAyB/Z8mXs9u+18gr6bblzasy+qnXk1BJ8+nbmw=="
     },
     "@dcl/kernel": {
       "version": "2.0.0-3488762509.commit-68db89b",
@@ -12434,9 +12758,9 @@
       }
     },
     "@dcl/react-ecs": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.5.tgz",
-      "integrity": "sha512-r9yLXhWZCpm/unO2u3r423IvoYgFWeG/PcyC+iyUvuuRQZY1BivV/YyVwR8M2KuY37jXVnmV5apV8TaoFjAi8A==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-W2FTu+o1kaXUFz0+eFlSn2fnZBM+QSw4iMvDvo8KVtZltAho2kW1mCysaeA89Rai8+8uygnK2rqqYj48DQcB5A==",
       "requires": {
         "@dcl/ecs": "file:../ecs",
         "react": "^18.2.0",
@@ -12496,28 +12820,150 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.5.tgz",
-      "integrity": "sha512-zKEbSS1yp+hQXRGNH4H+6Ix+4qvm9RW72uljXhCAc9S023Yeyro+Goz7CWyB6EoaECPeJagQHlMECLurlmNlLw==",
+      "version": "7.0.6-4077117821.commit-60bf97f",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.0.6-4077117821.commit-60bf97f.tgz",
+      "integrity": "sha512-eRgBo9JqmM2mpIB9DuPF3pCpbWSEwstW2o/OzImk0TH3Tx4eyNnTiYDPJztQCiTWfM2Q7JqutTiC1qcHjktbTA==",
       "requires": {
-        "@dcl/dcl-rollup": "7.0.5",
-        "@dcl/ecs": "7.0.5",
+        "@dcl/dcl-rollup": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/ecs": "7.0.6-4077117821.commit-60bf97f",
         "@dcl/ecs-math": "2.0.1-20221129185242.commit-40495c1",
-        "@dcl/js-runtime": "7.0.5",
-        "@dcl/kernel": "2.0.0-3640389337.commit-b563bb9",
-        "@dcl/react-ecs": "7.0.5",
-        "@dcl/unity-renderer": "1.0.66458-20221207172857.commit-1a83854"
+        "@dcl/explorer": "1.0.74928-20230130201703.commit-6da8317",
+        "@dcl/js-runtime": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/mini-comms": "1.0.0",
+        "@dcl/react-ecs": "7.0.6-4077117821.commit-60bf97f",
+        "@dcl/schemas": "6.6.0",
+        "@types/inquirer": "^8.2.5",
+        "@well-known-components/env-config-provider": "^1.1.2-20220801195549.commit-101c273",
+        "@well-known-components/http-server": "^1.1.6-20220927190058.commit-2dfb235",
+        "@well-known-components/logger": "^3.0.0",
+        "@well-known-components/metrics": "^2.0.1-20220909150423.commit-8f7e5bc",
+        "arg": "5.0.2",
+        "extract-zip": "2.0.1",
+        "inquirer": "^8.2.5",
+        "node-fetch": "^2.6.8",
+        "open": "^8.4.0",
+        "ora": "6.1.2",
+        "portfinder": "^1.0.32",
+        "undici": "^5.14.0"
       },
       "dependencies": {
-        "@dcl/kernel": {
-          "version": "2.0.0-3640389337.commit-b563bb9",
-          "resolved": "https://registry.npmjs.org/@dcl/kernel/-/kernel-2.0.0-3640389337.commit-b563bb9.tgz",
-          "integrity": "sha512-jKrSj8ev08BkJRYqtQhABJ9Xs/kXcmPpTMtsQf6hyPb8fqnsrBjHEFseM9/4LLZdRRydwFbADDGdOvRkjXPFmw=="
+        "@dcl/schemas": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.6.0.tgz",
+          "integrity": "sha512-8+y8NBeGq/A6AMr3FOPsmCY7ru4YUbpJkFKzmJe1dQH9Zq61/iHveJIamHJca5RCrB3D1oFPFs0KP6yWnMKElg==",
+          "requires": {
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-keywords": "^5.1.0"
+          }
         },
-        "@dcl/unity-renderer": {
-          "version": "1.0.66458-20221207172857.commit-1a83854",
-          "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.66458-20221207172857.commit-1a83854.tgz",
-          "integrity": "sha512-ZBiT5Yat2ePifMGrpdu2tqh0fyHM5lVNufEBxiPjqX1Q28uuMv5zsScCK4FnSR4VBcPli1SsU+ONWl7bIdYm3w=="
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
+        "chalk": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+        },
+        "cli-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+          "requires": {
+            "restore-cursor": "^4.0.0"
+          }
+        },
+        "is-interactive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+        },
+        "is-unicode-supported": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+          "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "log-symbols": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+          "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+          "requires": {
+            "chalk": "^5.0.0",
+            "is-unicode-supported": "^1.1.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+          "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "ora": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+          "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+          "requires": {
+            "bl": "^5.0.0",
+            "chalk": "^5.0.0",
+            "cli-cursor": "^4.0.0",
+            "cli-spinners": "^2.6.1",
+            "is-interactive": "^2.0.0",
+            "is-unicode-supported": "^1.1.0",
+            "log-symbols": "^5.1.0",
+            "strip-ansi": "^7.0.1",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
         }
       }
     },
@@ -12856,42 +13302,129 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.33.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.33.7.tgz",
-      "integrity": "sha512-fQT2v/j/55DhvMFiopLtth66E7xTFNhnumMKgKY14SaG6qU/V1W0e4nOAgbA+SmLakQjAd1Evu06ofaVaxBPbA==",
+      "version": "7.34.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.2.tgz",
+      "integrity": "sha512-oREyUU7p3JgjrqapJxEHe83gA1SXOWgaA4XCiY9PvsiLkgGHtn2ibTRgw9GCI/4kZzcb+OQv5waUDxsnQSKfwQ==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.25.3",
+        "@microsoft/api-extractor-model": "7.26.2",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3",
+        "@rushstack/node-core-library": "3.55.0",
         "@rushstack/rig-package": "0.3.17",
         "@rushstack/ts-command-line": "4.13.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
-        "resolve": "~1.17.0",
+        "resolve": "~1.22.1",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
         "typescript": "~4.8.4"
       },
       "dependencies": {
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "@rushstack/node-core-library": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.55.0.tgz",
+          "integrity": "sha512-6lSel8w3DeGaD/JCKw64wfezEBijlCQlMwBoYg9Ci5VPy+dZ+FpBkIBrY8mi3Ge4xNzr4gyTbQ5XEt0QP1Kv/w==",
           "requires": {
-            "path-parse": "^1.0.6"
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.22.1",
+            "semver": "~7.3.0",
+            "z-schema": "~5.0.2"
           }
+        },
+        "@types/node": {
+          "version": "14.18.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+          "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+          "optional": true,
+          "peer": true
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "typescript": {
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+          "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.25.3.tgz",
-      "integrity": "sha512-WWxBUq77p2iZ+5VF7Nmrm3y/UtqCh5bYV8ii3khwq3w99+fXWpvfsAhgSLsC7k8XDQc6De4ssMxH6He/qe1pzg==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.2.tgz",
+      "integrity": "sha512-V9tTHbYTNelTrNDXBzeDlszq29nQcjJdP6s27QJiATbqSRjEbKTeztlSVsCRHL2Wkkv5IN5jT4xkYjnFFPbK0A==",
       "requires": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3"
+        "@rushstack/node-core-library": "3.55.0"
+      },
+      "dependencies": {
+        "@rushstack/node-core-library": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.55.0.tgz",
+          "integrity": "sha512-6lSel8w3DeGaD/JCKw64wfezEBijlCQlMwBoYg9Ci5VPy+dZ+FpBkIBrY8mi3Ge4xNzr4gyTbQ5XEt0QP1Kv/w==",
+          "requires": {
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.22.1",
+            "semver": "~7.3.0",
+            "z-schema": "~5.0.2"
+          }
+        },
+        "@types/node": {
+          "version": "14.18.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+          "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+          "optional": true,
+          "peer": true
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
       }
     },
     "@microsoft/tsdoc": {
@@ -12991,9 +13524,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@rollup/plugin-commonjs": {
-      "version": "23.0.7",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.7.tgz",
-      "integrity": "sha512-hsSD5Qzyuat/swzrExGG5l7EuIlPhwTsT7KwKbSCQzIcJWjRxiimi/0tyMYY2bByitNb3i1p+6JWEDGa0NvT0Q==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
+      "integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
         "commondir": "^1.0.1",
@@ -13012,9 +13545,9 @@
           }
         },
         "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -13024,9 +13557,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -13056,17 +13589,19 @@
       }
     },
     "@rollup/plugin-terser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
-      "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
       "requires": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
         "terser": "^5.15.1"
       }
     },
     "@rollup/plugin-typescript": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-9.0.2.tgz",
-      "integrity": "sha512-/sS93vmHUMjzDUsl5scNQr1mUlNE1QjBBvOhmRwJCH8k2RRhDIm3c977B3wdu3t3Ap17W6dDeXP3hj1P1Un1bA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
         "resolve": "^1.22.1"
@@ -13080,59 +13615,6 @@
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
         "picomatch": "^2.3.1"
-      }
-    },
-    "@rushstack/node-core-library": {
-      "version": "3.53.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.3.tgz",
-      "integrity": "sha512-H0+T5koi5MFhJUd5ND3dI3bwLhvlABetARl78L3lWftJVQEPyzcgTStvTTRiIM5mCltyTM8VYm6BuCtNUuxD0Q==",
-      "requires": {
-        "@types/node": "12.20.24",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "z-schema": "~5.0.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        }
       }
     },
     "@rushstack/rig-package": {
@@ -13448,6 +13930,14 @@
         "@types/node": "*"
       }
     },
+    "@types/inquirer": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QXlzybid60YtAwfgG3cpykptRYUx2KomzNutMlWsQC64J/WG/gQSl+P4w7A21sGN0VIxRVava4rgnT7FQmFCdg==",
+      "requires": {
+        "@types/through": "*"
+      }
+    },
     "@types/is-running": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-running/-/is-running-2.1.0.tgz",
@@ -13608,6 +14098,14 @@
       "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
       "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
       "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
       "requires": {
         "@types/node": "*"
       }
@@ -14219,6 +14717,14 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -15928,9 +16434,9 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
-      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -16032,9 +16538,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "requires": {
         "builtin-modules": "^3.3.0"
       }
@@ -19381,6 +19887,14 @@
         "readable-stream": "^3.6.0"
       }
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -19634,9 +20148,9 @@
       }
     },
     "rollup": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
-      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
+      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -19645,14 +20159,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz",
       "integrity": "sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ=="
-    },
-    "rollup-plugin-api-extractor": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-api-extractor/-/rollup-plugin-api-extractor-0.2.5.tgz",
-      "integrity": "sha512-oWG57yqB6n/xn2egrbiOFjgKjIt/GCwbcdQHaDDM5s26RvwBfckCIokCP3reZCS1OQnINw8NOPcJNarTjef8rA==",
-      "requires": {
-        "@microsoft/api-extractor": "^7.19.0"
-      }
     },
     "run-async": {
       "version": "2.4.1",
@@ -19741,6 +20247,14 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -19812,6 +20326,11 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw=="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19870,6 +20389,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -20269,9 +20793,9 @@
       "integrity": "sha512-762imXO+myoSDHD9+YxUfSmfT0yGH1j+3s9UJ6uqKkOYIwHH6/gsFo67ZoST0Ey/RSoaps1zGu1N+eiuuCxfeg=="
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -20292,6 +20816,14 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
+      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "universalify": {
       "version": "2.0.0",
@@ -20388,9 +20920,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "varint": {
       "version": "6.0.0",
@@ -20691,9 +21223,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "9.4.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   },
   "dependencies": {
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "^7.0.6-4077117821.commit-60bf97f",
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   },
   "dependencies": {
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "^7.0.5",
+    "@dcl/sdk": "^7.0.6-4077117821.commit-60bf97f",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -422,7 +422,7 @@
   },
   "dependencies": {
     "@dcl/schemas": "^5.18.1",
-    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/update/init-move-out/dcl-sdk-7.0.6-4085012314.commit-c9b83a3.tgz",
+    "@dcl/sdk": "^7.0.6-4085247017.commit-f004317",
     "@dcl/wearable-preview": "^1.14.0",
     "@types/analytics-node": "^3.1.9",
     "@types/cmd-shim": "^5.0.0",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -17,6 +17,7 @@ export const window = {
     ),
   showWarningMessage: jest.fn(),
   showErrorMessage: jest.fn(),
+  showQuickPick: jest.fn(),
 }
 
 export const ProgressLocation = {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -139,9 +139,13 @@ export async function initSdk6(type: ProjectType, templateUrl?: string) {
 }
 
 export async function initSdk7() {
-  const child = bin('@dcl/sdk', 'sdk-commands', ['init', `--skip-install`])
+  const child = bin('@dcl/sdk', 'sdk-commands', ['init'])
 
-  await child.wait()
+  await loader(
+    `Creating project...`,
+    () => child.wait(),
+    vscode.ProgressLocation.Notification
+  )
 
   await npmInstall()
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { browser } from './commands/browser'
 import { uninstall } from './commands/uninstall'
 import { deploy } from './commands/deploy'
 import { createTree, registerTree } from './views/dependency-tree/tree'
-import { init } from './commands/init'
+import { init, initSdk6 } from './commands/init'
 import { restart } from './commands/restart'
 import { Dependency } from './views/dependency-tree/types'
 import { npmInstall, npmUninstall } from './modules/npm'
@@ -170,7 +170,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Walkthrough
     registerCommand('walkthrough.createProject', () =>
-      init(ProjectType.SCENE).then(validate)
+      // The walkthrough creates an SDK6 project
+      initSdk6(ProjectType.SCENE).then(validate)
     )
     registerCommand('walkthrough.viewCode', () => {
       vscode.commands.executeCommand(

--- a/src/modules/pick.spec.ts
+++ b/src/modules/pick.spec.ts
@@ -1,0 +1,61 @@
+import { QuickPickItem, window } from 'vscode'
+import { pick } from './pick'
+
+const showQuickPickMock = window.showQuickPick as jest.MockedFunction<
+  typeof window.showQuickPick
+>
+
+const items = [
+  {
+    label: 'First Item',
+    value: 'first',
+  },
+  {
+    label: 'Second Item',
+    value: 'second',
+  },
+  {
+    label: 'Third Item',
+    value: 'third',
+  },
+]
+
+describe('picker', () => {
+  describe('When picking an item', () => {
+    afterEach(() => {
+      showQuickPickMock.mockRestore()
+    })
+    it('should show a list of using the values from the labels of the items', async () => {
+      await pick(items, 'label', {})
+      expect(showQuickPickMock).toHaveBeenCalledWith(
+        ['First Item', 'Second Item', 'Third Item'],
+        {}
+      )
+    })
+    describe('and the user selects an option', () => {
+      beforeEach(() => {
+        showQuickPickMock.mockImplementation((items) => (items as any)[0])
+      })
+      afterEach(() => {
+        showQuickPickMock.mockRestore()
+      })
+      it('should return the selected item', async () => {
+        await expect(pick(items, 'label')).resolves.toEqual({
+          label: 'First Item',
+          value: 'first',
+        })
+      })
+    })
+    describe('and the user does not select an option', () => {
+      beforeEach(() => {
+        showQuickPickMock.mockResolvedValueOnce(undefined)
+      })
+      afterEach(() => {
+        showQuickPickMock.mockRestore()
+      })
+      it('should return null', async () => {
+        await expect(pick(items, 'label')).resolves.toBe(null)
+      })
+    })
+  })
+})

--- a/src/modules/pick.ts
+++ b/src/modules/pick.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode'
+
+/**
+ * Helper to pick an item from a list, by showing options to the user
+ * @param items
+ * @param labelKey
+ * @param options
+ * @returns
+ */
+export async function pick<T>(
+  items: T[],
+  labelKey: keyof T,
+  options?: vscode.QuickPickOptions
+) {
+  const labels = items.map((item) => item[labelKey] as string)
+  const selectedLabel = await vscode.window.showQuickPick(labels, options)
+  const selectedItem = items.find((item) => item[labelKey] === selectedLabel)
+  return selectedItem || null
+}

--- a/src/modules/project.spec.ts
+++ b/src/modules/project.spec.ts
@@ -1,4 +1,4 @@
-import { getTemplates, getTypeOptions } from './project'
+import { getTemplates, getProjectTypeOptions, getSdkOptions } from './project'
 
 /********************************************************
                           Tests
@@ -7,12 +7,17 @@ import { getTemplates, getTypeOptions } from './project'
 describe('project', () => {
   describe('When getting the project type options', () => {
     it('should return the 4 options', () => {
-      expect(getTypeOptions()).toHaveLength(4)
+      expect(getProjectTypeOptions()).toHaveLength(4)
     })
   })
   describe('When getting the templates', () => {
     it('should return the list of templates', () => {
       expect(getTemplates()).toEqual(expect.any(Array))
+    })
+  })
+  describe('When getting the SDK options', () => {
+    it('should return the 2 options', () => {
+      expect(getSdkOptions()).toHaveLength(2)
     })
   })
 })

--- a/src/modules/project.ts
+++ b/src/modules/project.ts
@@ -1,5 +1,23 @@
 import { repos } from 'decentraland/dist/commands/init/repositories'
 
+export enum SdkVersion {
+  SDK6 = 'sdk6',
+  SDK7 = 'sdk7',
+}
+
+export function getSdkOptions() {
+  return [
+    {
+      version: SdkVersion.SDK6,
+      name: 'SDK6',
+    },
+    {
+      version: SdkVersion.SDK7,
+      name: 'SDK7 (Beta)',
+    },
+  ]
+}
+
 export enum ProjectType {
   SCENE = 'scene',
   LIBRARY = 'library',
@@ -7,7 +25,7 @@ export enum ProjectType {
   SMART_ITEM = 'smartItem',
 }
 
-export function getTypeOptions() {
+export function getProjectTypeOptions() {
   const options: { type: ProjectType; name: string }[] = [
     {
       type: ProjectType.SCENE,

--- a/src/modules/spawn.spec.ts
+++ b/src/modules/spawn.spec.ts
@@ -230,7 +230,7 @@ describe('When spawning a child process', () => {
     it('should reject the promise', () => {
       spawn('id', 'command')
       expect(promiseMock.reject).toHaveBeenCalledWith(
-        new Error('Error: process "command" exited with code=1')
+        new Error('Error: process "id" with pid=1 exited with code=1')
       )
     })
   })

--- a/src/modules/spawn.spec.ts
+++ b/src/modules/spawn.spec.ts
@@ -230,7 +230,7 @@ describe('When spawning a child process', () => {
     it('should reject the promise', () => {
       spawn('id', 'command')
       expect(promiseMock.reject).toHaveBeenCalledWith(
-        new Error('Error: process "command" exited with code "1".')
+        new Error('Error: process "command" exited with code=1')
       )
     })
   })

--- a/src/modules/spawn.ts
+++ b/src/modules/spawn.ts
@@ -77,9 +77,12 @@ export function spawn(
 
   child.on('close', (code) => {
     alive = false
+    log(
+      `Process "${id}" with pid=${child.pid} closed with exit code=${code || 0}`
+    )
     if (code !== 0 && code !== null) {
       promise.reject(
-        new Error(`Error: process "${command}" exited with code "${code}".`)
+        new Error(`Error: process "${command}" exited with code=${code}`)
       )
     } else {
       promise.resolve(void 0)

--- a/src/modules/spawn.ts
+++ b/src/modules/spawn.ts
@@ -82,7 +82,9 @@ export function spawn(
     )
     if (code !== 0 && code !== null) {
       promise.reject(
-        new Error(`Error: process "${command}" exited with code=${code}`)
+        new Error(
+          `Error: process "${id}" with pid=${child.pid} exited with code=${code}`
+        )
       )
     } else {
       promise.resolve(void 0)


### PR DESCRIPTION
This PR adds the ability to initialize an SDK7 project. It splits the `init` command into two other function `initSdk6` and `initSdk7` so they can have their own project types and templates. The walkthrough still uses the sdk 6 template. 

Added tracking to know which sdk version the users are initializing with.

Also added a `pick` helper to reduce repetition of code whenever we needed the user to select a value from a list, and added tests.

**BLOCKED**: This is blocked until we can use the `latest` release of `@dcl/sdk` instead of `next`, otherwise the `next` version does not work with the `sdk7-scene-template`.