### PR TITLE
fix: namespace context

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
       },
       {
         "view": "decentraland-sdk7.home",
-        "contents": "The current folder is empty, go ahead and create a new Decentraland project:\n[Create Project](command:decentraland-sdk7.commands.init)\nTo learn more [read our docs](https://docs.decentraland.org/).",
+        "contents": "The current folder is empty, go ahead and create a new Decentraland SDK7 project:\n[Create Project](command:decentraland-sdk7.commands.init)\nTo learn more [read our docs](https://docs.decentraland.org/).",
         "when": "workbenchState != empty && !decentraland-sdk7.isDCL && decentraland.isEmpty"
       },
       {
         "view": "decentraland-sdk7.home",
-        "contents": "The current folder does not contain a Decentraland project. Open a folder with an existing project, or an empty folder to scaffold a new project:\n[Open Folder](command:vscode.openFolder)\nTo learn more [read our docs](https://docs.decentraland.org/).",
+        "contents": "The current folder does not contain a Decentraland SDK7 project. Open a folder with an existing project, or an empty folder to scaffold a new project:\n[Open Folder](command:vscode.openFolder)\nTo learn more [read our docs](https://docs.decentraland.org/).",
         "when": "workbenchState != empty && !decentraland-sdk7.isDCL && !decentraland.isEmpty"
       },
       {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         {
           "id": "decentraland-sdk7.dependencies",
           "name": "Dependencies",
-          "when": "decentraland.isDCL"
+          "when": "decentraland-sdk7.isDCL"
         }
       ]
     },
@@ -70,22 +70,22 @@
       {
         "view": "decentraland-sdk7.home",
         "contents": "The current folder is empty, go ahead and create a new Decentraland project:\n[Create Project](command:decentraland-sdk7.commands.init)\nTo learn more [read our docs](https://docs.decentraland.org/).",
-        "when": "workbenchState != empty && !decentraland.isDCL && decentraland.isEmpty"
+        "when": "workbenchState != empty && !decentraland-sdk7.isDCL && decentraland.isEmpty"
       },
       {
         "view": "decentraland-sdk7.home",
         "contents": "The current folder does not contain a Decentraland project. Open a folder with an existing project, or an empty folder to scaffold a new project:\n[Open Folder](command:vscode.openFolder)\nTo learn more [read our docs](https://docs.decentraland.org/).",
-        "when": "workbenchState != empty && !decentraland.isDCL && !decentraland.isEmpty"
+        "when": "workbenchState != empty && !decentraland-sdk7.isDCL && !decentraland.isEmpty"
       },
       {
         "view": "decentraland-sdk7.home",
         "contents": "You can preview and try out your scene:\n[Run Scene](command:decentraland-sdk7.commands.start)",
-        "when": "workbenchState != empty && decentraland.isDCL"
+        "when": "workbenchState != empty && decentraland-sdk7.isDCL"
       },
       {
         "view": "decentraland-sdk7.home",
         "contents": "Once you are done building your scene, you can publish it to Genesis City:\n[Publish Scene](command:decentraland-sdk7.commands.deploy)",
-        "when": "workbenchState != empty && decentraland.isDCL"
+        "when": "workbenchState != empty && decentraland-sdk7.isDCL"
       }
     ],
     "customEditors": [
@@ -104,14 +104,14 @@
       {
         "command": "decentraland-sdk7.commands.init",
         "title": "Create Project",
-        "enablement": "!decentraland.isDCL",
+        "enablement": "!decentraland-sdk7.isDCL",
         "category": "Decentraland"
       },
       {
         "command": "decentraland-sdk7.commands.install",
         "title": "Install Package",
         "icon": "$(add)",
-        "enablement": "decentraland.isDCL",
+        "enablement": "decentraland-sdk7.isDCL",
         "category": "Decentraland"
       },
       {
@@ -206,7 +206,7 @@
         "command": "decentraland-sdk7.commands.start",
         "key": "ctrl+e",
         "mac": "cmd+e",
-        "when": "decentraland.isDCL"
+        "when": "decentraland-sdk7.isDCL"
       }
     ],
     "menus": {
@@ -247,32 +247,32 @@
       "view/title": [
         {
           "command": "decentraland-sdk7.commands.deployWorld",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "1_actions@1"
         },
         {
           "command": "decentraland-sdk7.commands.deployTest",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "1_actions@2"
         },
         {
           "command": "decentraland-sdk7.commands.deployCustom",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "1_actions@3"
         },
         {
           "command": "decentraland-sdk7.commands.browser.web3",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "1_actions@4"
         },
         {
           "command": "decentraland-sdk7.commands.inspector",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "1_actions@5"
         },
         {
           "command": "decentraland-sdk7.commands.restart",
-          "when": "view == decentraland-sdk7.home && decentraland.isDCL",
+          "when": "view == decentraland-sdk7.home && decentraland-sdk7.isDCL",
           "group": "navigation"
         },
         {

--- a/package.json
+++ b/package.json
@@ -20,20 +20,7 @@
   ],
   "activationEvents": [
     "onDebug",
-    "onView:decentraland-sdk7.home",
-    "onView:decentraland-sdk7.dependencies",
-    "onCustomEditor:decentraland-sdk7.GLTFPreview",
-    "onCommand:decentraland-sdk7.commands.update",
-    "onCommand:decentraland-sdk7.commands.install",
-    "onCommand:decentraland-sdk7.commands.uninstall",
-    "onCommand:decentraland-sdk7.commands.start",
-    "onCommand:decentraland-sdk7.commands.deploy",
-    "onCommand:decentraland-sdk7.commands.deployWorld",
-    "onCommand:decentraland-sdk7.commands.deployTest",
-    "onCommand:decentraland-sdk7.commands.deployCustom",
     "onCommand:decentraland-sdk7.commands.runInspector",
-    "onCommand:decentraland-sdk7.dependencies.delete",
-    "onCommand:decentraland-sdk7.dependencies.update",
     "onCommand:decentraland-sdk7.walkthrough.createProject",
     "onCommand:decentraland-sdk7.walkthrough.viewCode"
   ],
@@ -52,7 +39,7 @@
       "decentraland-sdk7": [
         {
           "id": "decentraland-sdk7.home",
-          "name": "Decentraland SDK7"
+          "name": "Editor"
         },
         {
           "id": "decentraland-sdk7.dependencies",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,7 +236,7 @@ export async function validate() {
   // Set in context if it is valid project
   await vscode.commands.executeCommand(
     'setContext',
-    'decentraland.isDCL',
+    'decentraland-sdk7.isDCL',
     isDCL()
   )
 

--- a/src/modules/pkg.spec.ts
+++ b/src/modules/pkg.spec.ts
@@ -1,4 +1,4 @@
-import { getPackageJson, getPackageVersion } from './pkg'
+import { getPackageJson, getPackageVersion, hasDependency } from './pkg'
 
 /********************************************************
                           Mocks
@@ -113,6 +113,45 @@ describe('pkg', () => {
       })
       it('should return null', () => {
         expect(getPackageVersion('some-non-existent-module')).toBeNull()
+      })
+    })
+  })
+  describe('When checking if a module is a dependency', () => {
+    describe('and the module is in the dependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce(
+          '{ "dependencies": { "my-dependency": "1.0.0" } }'
+        )
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(true)
+      })
+    })
+    describe('and the module is in the devDependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce(
+          '{ "devDependencies": { "my-dependency": "1.0.0" } }'
+        )
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(true)
+      })
+    })
+    describe('and the module is neither in the dependencies nor the devDependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce('{ "version": "1.0.0" }')
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(false)
       })
     })
   })

--- a/src/modules/pkg.ts
+++ b/src/modules/pkg.ts
@@ -17,8 +17,8 @@ export function getPackageJson(
     node: string
   }
   bin?: { [command: string]: string }
-  dependencies: Record<string, string>
-  devDependencies: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
 } {
   const basePath = workspace ? getCwd() : getExtensionPath()
   const packageJsonPath = !!moduleName
@@ -44,4 +44,15 @@ export function getPackageVersion(moduleName?: string, workspace = false) {
   } catch (error) {
     return null
   }
+}
+
+/**
+ * Returns whether or not there's a dependency on a module
+ */
+export function hasDependency(moduleName: string, workspace = false) {
+  const pkg = getPackageJson(undefined, workspace)
+  const isDependency = !!pkg.dependencies && moduleName in pkg.dependencies
+  const isDevDependency =
+    !!pkg.devDependencies && moduleName in pkg.devDependencies
+  return isDependency || isDevDependency
 }

--- a/src/modules/pkg.ts
+++ b/src/modules/pkg.ts
@@ -17,6 +17,7 @@ export function getPackageJson(
     node: string
   }
   bin?: { [command: string]: string }
+  dependencies: Record<string, string>
 } {
   const basePath = workspace ? getCwd() : getExtensionPath()
   const packageJsonPath = !!moduleName

--- a/src/modules/pkg.ts
+++ b/src/modules/pkg.ts
@@ -18,6 +18,7 @@ export function getPackageJson(
   }
   bin?: { [command: string]: string }
   dependencies: Record<string, string>
+  devDependencies: Record<string, string>
 } {
   const basePath = workspace ? getCwd() : getExtensionPath()
   const packageJsonPath = !!moduleName

--- a/src/modules/workspace.spec.ts
+++ b/src/modules/workspace.spec.ts
@@ -18,6 +18,12 @@ const fsExistsSyncMock = fs.existsSync as jest.MockedFunction<
   typeof fs.existsSync
 >
 
+import { hasDependency } from './pkg'
+jest.mock('./pkg')
+const hasDependencyMock = hasDependency as jest.MockedFunction<
+  typeof hasDependency
+>
+
 /********************************************************
                           Tests
 *********************************************************/
@@ -68,8 +74,27 @@ describe('workspace', () => {
       afterEach(() => {
         fsReadFileSyncMock.mockReset()
       })
-      it('should read the scene json file from the file system', () => {
-        expect(isDCL()).toBe(true)
+      describe('and the workspace has a dependency on @dcl/sdk', () => {
+        beforeEach(() => {
+          hasDependencyMock.mockReturnValueOnce(true)
+        })
+        afterEach(() => {
+          hasDependencyMock.mockReset()
+        })
+        it('should return true', () => {
+          expect(isDCL()).toBe(true)
+        })
+      })
+      describe('and the workspace does not have a dependency on @dcl/sdk', () => {
+        beforeEach(() => {
+          hasDependencyMock.mockReturnValueOnce(false)
+        })
+        afterEach(() => {
+          hasDependencyMock.mockReset()
+        })
+        it('should return false', () => {
+          expect(isDCL()).toBe(false)
+        })
       })
     })
     describe('and the workspace does not have a scene.json', () => {

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -36,7 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    return hasDependency('@dcl/sdk')
+    return hasDependency('@dcl/sdk', true)
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -36,8 +36,8 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    getPackageJson('@dcl/sdk', true)
-    return true
+    const pkg = getPackageJson()
+    return '@dcl/sdk' in pkg.dependencies
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import fs from 'fs'
 import path from 'path'
 import { Scene } from '@dcl/schemas'
+import { getPackageJson } from './pkg'
 
 /**
  * Returns the path to the workspace's current working directory
@@ -35,6 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
+    getPackageJson('@dcl/sdk', true)
     return true
   } catch (error) {
     return false

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import fs from 'fs'
 import path from 'path'
 import { Scene } from '@dcl/schemas'
-import { getPackageJson } from './pkg'
+import { hasDependency } from './pkg'
 
 /**
  * Returns the path to the workspace's current working directory
@@ -36,8 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    const pkg = getPackageJson(undefined, true)
-    return '@dcl/sdk' in pkg.dependencies || '@dcl/sdk' in pkg.devDependencies
+    return hasDependency('@dcl/sdk')
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -36,8 +36,8 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    const pkg = getPackageJson()
-    return '@dcl/sdk' in pkg.dependencies
+    const pkg = getPackageJson(undefined, true)
+    return '@dcl/sdk' in pkg.dependencies || '@dcl/sdk' in pkg.devDependencies
   } catch (error) {
     return false
   }


### PR DESCRIPTION
This PR namespaces the context variable `decentraland.isDCL` so it does not collide with the one in production.
It also adds a check for the `@dcl/sdk` dependency to determine if the project is valid.