### PR TITLE
chore: rename sdk6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,6 @@
   ],
   "activationEvents": [
     "onDebug",
-    "onView:decentraland",
-    "onView:dependencies",
-    "onCustomEditor:decentraland.GLTFPreview",
-    "onCommand:decentraland.commands.update",
-    "onCommand:decentraland.commands.install",
-    "onCommand:decentraland.commands.uninstall",
-    "onCommand:decentraland.commands.start",
-    "onCommand:decentraland.commands.deploy",
-    "onCommand:decentraland.commands.deployWorld",
-    "onCommand:decentraland.commands.deployTest",
-    "onCommand:decentraland.commands.deployCustom",
-    "onCommand:dependencies.commands.delete",
-    "onCommand:dependencies.commands.update",
     "onCommand:walkthrough.createProject",
     "onCommand:walkthrough.viewCode"
   ],
@@ -42,7 +29,7 @@
       "activitybar": [
         {
           "id": "decentraland",
-          "title": "Decentraland",
+          "title": "Decentraland SDK6",
           "icon": "resources/activitybar.svg"
         }
       ]
@@ -51,7 +38,7 @@
       "decentraland": [
         {
           "id": "decentraland",
-          "name": "Decentraland"
+          "name": "Editor"
         },
         {
           "id": "dependencies",
@@ -68,12 +55,12 @@
       },
       {
         "view": "decentraland",
-        "contents": "The current folder is empty, go ahead and create a new Decentraland project:\n[Create Project](command:decentraland.commands.init)\nTo learn more [read our docs](https://docs.decentraland.org/).",
+        "contents": "The current folder is empty, go ahead and create a new Decentraland SDK6 project:\n[Create Project](command:decentraland.commands.init)\nTo learn more [read our docs](https://docs.decentraland.org/).",
         "when": "workbenchState != empty && !decentraland.isDCL && decentraland.isEmpty"
       },
       {
         "view": "decentraland",
-        "contents": "The current folder does not contain a Decentraland project. Open a folder with an existing project, or an empty folder to scaffold a new project:\n[Open Folder](command:vscode.openFolder)\nTo learn more [read our docs](https://docs.decentraland.org/).",
+        "contents": "The current folder does not contain a Decentraland SDK6 project. Open a folder with an existing project, or an empty folder to scaffold a new project:\n[Open Folder](command:vscode.openFolder)\nTo learn more [read our docs](https://docs.decentraland.org/).",
         "when": "workbenchState != empty && !decentraland.isDCL && !decentraland.isEmpty"
       },
       {

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { SpanwedChild } from './spawn'
 
-export const output = vscode.window.createOutputChannel(`Decentraland`)
+export const output = vscode.window.createOutputChannel(`Decentraland SDK6`)
 
 /**
  * Append a message to the output

--- a/src/modules/pkg.spec.ts
+++ b/src/modules/pkg.spec.ts
@@ -1,4 +1,4 @@
-import { getPackageJson, getPackageVersion } from './pkg'
+import { getPackageJson, getPackageVersion, hasDependency } from './pkg'
 
 /********************************************************
                           Mocks
@@ -113,6 +113,45 @@ describe('pkg', () => {
       })
       it('should return null', () => {
         expect(getPackageVersion('some-non-existent-module')).toBeNull()
+      })
+    })
+  })
+  describe('When checking if a module is a dependency', () => {
+    describe('and the module is in the dependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce(
+          '{ "dependencies": { "my-dependency": "1.0.0" } }'
+        )
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(true)
+      })
+    })
+    describe('and the module is in the devDependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce(
+          '{ "devDependencies": { "my-dependency": "1.0.0" } }'
+        )
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(true)
+      })
+    })
+    describe('and the module is neither in the dependencies nor the devDependencies of the package.json', () => {
+      beforeEach(() => {
+        fsReadFileSyncMock.mockReturnValueOnce('{ "version": "1.0.0" }')
+      })
+      afterEach(() => {
+        fsReadFileSyncMock.mockReset()
+      })
+      it('should return true', () => {
+        expect(hasDependency('my-dependency')).toBe(false)
       })
     })
   })

--- a/src/modules/pkg.ts
+++ b/src/modules/pkg.ts
@@ -17,6 +17,8 @@ export function getPackageJson(
     node: string
   }
   bin?: { [command: string]: string }
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
 } {
   const basePath = workspace ? getCwd() : getExtensionPath()
   const packageJsonPath = !!moduleName

--- a/src/modules/pkg.ts
+++ b/src/modules/pkg.ts
@@ -17,8 +17,8 @@ export function getPackageJson(
     node: string
   }
   bin?: { [command: string]: string }
-  dependencies: Record<string, string>
-  devDependencies: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
 } {
   const basePath = workspace ? getCwd() : getExtensionPath()
   const packageJsonPath = !!moduleName
@@ -44,4 +44,15 @@ export function getPackageVersion(moduleName?: string, workspace = false) {
   } catch (error) {
     return null
   }
+}
+
+/**
+ * Returns whether or not there's a dependency on a module
+ */
+export function hasDependency(moduleName: string, workspace = false) {
+  const pkg = getPackageJson(undefined, workspace)
+  const isDependency = !!pkg.dependencies && moduleName in pkg.dependencies
+  const isDevDependency =
+    !!pkg.devDependencies && moduleName in pkg.devDependencies
+  return isDependency || isDevDependency
 }

--- a/src/modules/workspace.spec.ts
+++ b/src/modules/workspace.spec.ts
@@ -18,6 +18,12 @@ const fsExistsSyncMock = fs.existsSync as jest.MockedFunction<
   typeof fs.existsSync
 >
 
+import { hasDependency } from './pkg'
+jest.mock('./pkg')
+const hasDependencyMock = hasDependency as jest.MockedFunction<
+  typeof hasDependency
+>
+
 /********************************************************
                           Tests
 *********************************************************/
@@ -68,8 +74,27 @@ describe('workspace', () => {
       afterEach(() => {
         fsReadFileSyncMock.mockReset()
       })
-      it('should read the scene json file from the file system', () => {
-        expect(isDCL()).toBe(true)
+      describe('and the workspace has a dependency on @dcl/sdk', () => {
+        beforeEach(() => {
+          hasDependencyMock.mockReturnValueOnce(true)
+        })
+        afterEach(() => {
+          hasDependencyMock.mockReset()
+        })
+        it('should return true', () => {
+          expect(isDCL()).toBe(true)
+        })
+      })
+      describe('and the workspace does not have a dependency on @dcl/sdk', () => {
+        beforeEach(() => {
+          hasDependencyMock.mockReturnValueOnce(false)
+        })
+        afterEach(() => {
+          hasDependencyMock.mockReset()
+        })
+        it('should return false', () => {
+          expect(isDCL()).toBe(false)
+        })
       })
     })
     describe('and the workspace does not have a scene.json', () => {

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -36,7 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    return hasDependency('decentraland-ecs')
+    return hasDependency('decentraland-ecs', true)
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -36,8 +36,11 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    getPackageJson('decentraland-ecs', true)
-    return true
+    const pkg = getPackageJson(undefined, true)
+    return (
+      'decentraland-ecs' in pkg.dependencies ||
+      'decentraland-ecs' in pkg.devDependencies
+    )
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import fs from 'fs'
 import path from 'path'
 import { Scene } from '@dcl/schemas'
-import { getPackageJson } from './pkg'
+import { hasDependency } from './pkg'
 
 /**
  * Returns the path to the workspace's current working directory
@@ -36,11 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
-    const pkg = getPackageJson(undefined, true)
-    return (
-      'decentraland-ecs' in pkg.dependencies ||
-      'decentraland-ecs' in pkg.devDependencies
-    )
+    return hasDependency('decentraland-ecs')
   } catch (error) {
     return false
   }

--- a/src/modules/workspace.ts
+++ b/src/modules/workspace.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import fs from 'fs'
 import path from 'path'
 import { Scene } from '@dcl/schemas'
+import { getPackageJson } from './pkg'
 
 /**
  * Returns the path to the workspace's current working directory
@@ -35,6 +36,7 @@ export function getScene() {
 export function isDCL() {
   try {
     getScene()
+    getPackageJson('decentraland-ecs', true)
     return true
   } catch (error) {
     return false


### PR DESCRIPTION
This PR renames some stuff to SDK6 so they can be distinguished from the new SDK7 extension. It also checks for the `decentraland-ecs` dependency to determine if a project is valid.